### PR TITLE
[FEAT] HubStock 서비스로직 작성

### DIFF
--- a/src/main/java/followMe/hub_server/stock/application/dto/CreateHubStockDto.java
+++ b/src/main/java/followMe/hub_server/stock/application/dto/CreateHubStockDto.java
@@ -1,0 +1,39 @@
+package followMe.hub_server.stock.application.dto;
+
+import com.followMe.common.util.TimeUtil;
+import followMe.hub_server.stock.domain.HubStock;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class CreateHubStockDto {
+
+  @Getter
+  @AllArgsConstructor
+  public static class CreateHubStockRequest {
+    private UUID productId;
+    private String productCode;
+    private String productName;
+    private UUID hubId;
+    private UUID vendorId;
+    private String vendorName;
+    private Integer quantity;
+  }
+
+  @Getter
+  @AllArgsConstructor
+  @Builder
+  public static class CreateHubStockResponse {
+    private UUID productId;
+    private LocalDateTime createdAt;
+
+    public static CreateHubStockResponse from(HubStock hubStock) {
+      return CreateHubStockResponse.builder()
+          .productId(hubStock.getProductId())
+          .createdAt(TimeUtil.toLocalDateTime(hubStock.getCreatedAt()))
+          .build();
+    }
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/application/dto/DeleteHubStockDto.java
+++ b/src/main/java/followMe/hub_server/stock/application/dto/DeleteHubStockDto.java
@@ -1,0 +1,14 @@
+package followMe.hub_server.stock.application.dto;
+
+import followMe.hub_server.stock.domain.Type;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class DeleteHubStockDto {
+
+  @Getter
+  @AllArgsConstructor
+  public static class DeleteHubStockRequest {
+    private Type type;
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/application/dto/OrderHubStockDto.java
+++ b/src/main/java/followMe/hub_server/stock/application/dto/OrderHubStockDto.java
@@ -1,0 +1,42 @@
+package followMe.hub_server.stock.application.dto;
+
+import com.followMe.common.util.TimeUtil;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class OrderHubStockDto {
+
+  @Getter
+  @AllArgsConstructor
+  public static class OrderHubStockRequest {
+    private UUID orderId;
+    private List<Product> products;
+
+    @Getter
+    @AllArgsConstructor
+    public static class Product {
+      private UUID id;
+      private Integer quantity;
+    }
+  }
+
+  @Getter
+  @AllArgsConstructor
+  @Builder
+  public static class OrderHubStockResponse {
+    private UUID orderId;
+    private LocalDateTime completedAt;
+
+    public static OrderHubStockResponse from(UUID orderId, Instant completedAt) {
+      return OrderHubStockResponse.builder()
+          .orderId(orderId)
+          .completedAt(TimeUtil.toLocalDateTime(completedAt))
+          .build();
+    }
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/application/dto/SearchCondition.java
+++ b/src/main/java/followMe/hub_server/stock/application/dto/SearchCondition.java
@@ -1,0 +1,13 @@
+package followMe.hub_server.stock.application.dto;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SearchCondition {
+  private UUID productId;
+  private UUID hubId;
+  private UUID vendorId;
+}

--- a/src/main/java/followMe/hub_server/stock/application/dto/SearchProductIdsRequest.java
+++ b/src/main/java/followMe/hub_server/stock/application/dto/SearchProductIdsRequest.java
@@ -1,0 +1,18 @@
+package followMe.hub_server.stock.application.dto;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SearchProductIdsRequest {
+  private List<RequestProduct> products;
+
+  @Getter
+  @AllArgsConstructor
+  public static class RequestProduct {
+    private UUID id;
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/application/dto/SearchResponse.java
+++ b/src/main/java/followMe/hub_server/stock/application/dto/SearchResponse.java
@@ -1,0 +1,31 @@
+package followMe.hub_server.stock.application.dto;
+
+import followMe.hub_server.stock.domain.HubStock;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class SearchResponse {
+  UUID productId;
+  String productCode;
+  String productName;
+  UUID hubId;
+  Integer quantity;
+
+  public static Page<SearchResponse> from(Page<HubStock> hubStocks) {
+    return hubStocks.map(
+        stock ->
+            SearchResponse.builder()
+                .productId(stock.getProductId())
+                .productCode(stock.getProductInfo().getProductCode())
+                .productName(stock.getProductInfo().getProductName())
+                .hubId(stock.getHubId())
+                .quantity(stock.getQuantity())
+                .build());
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/application/dto/UpdateHubStockDto.java
+++ b/src/main/java/followMe/hub_server/stock/application/dto/UpdateHubStockDto.java
@@ -1,0 +1,35 @@
+package followMe.hub_server.stock.application.dto;
+
+import com.followMe.common.util.TimeUtil;
+import followMe.hub_server.stock.domain.HubStock;
+import followMe.hub_server.stock.domain.Type;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class UpdateHubStockDto {
+
+  @Getter
+  @AllArgsConstructor
+  public static class UpdateHubStockRequest {
+    Type type;
+    Integer quantity;
+  }
+
+  @Getter
+  @AllArgsConstructor
+  @Builder
+  public static class UpdateHubStockResponse {
+    private UUID productId;
+    private LocalDateTime updatedAt;
+
+    public static UpdateHubStockResponse from(HubStock hubStock) {
+      return UpdateHubStockResponse.builder()
+          .productId(hubStock.getProductId())
+          .updatedAt(TimeUtil.toLocalDateTime(hubStock.getCreatedAt()))
+          .build();
+    }
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/application/dto/history/SearchStockHistoryResponse.java
+++ b/src/main/java/followMe/hub_server/stock/application/dto/history/SearchStockHistoryResponse.java
@@ -1,0 +1,46 @@
+package followMe.hub_server.stock.application.dto.history;
+
+import com.followMe.common.util.TimeUtil;
+import followMe.hub_server.stock.domain.HubStockHistory;
+import followMe.hub_server.stock.domain.Type;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SearchStockHistoryResponse {
+  private UUID productId;
+  private String productCode;
+  private String productName;
+  private UUID vendorId;
+  private String vendorName;
+  private UUID hubId;
+  private Type type;
+  private UUID refId;
+  private Integer beforeQuantity;
+  private Integer afterQuantity;
+  private LocalDateTime createdAt;
+
+  public static Page<SearchStockHistoryResponse> from(Page<HubStockHistory> histories) {
+    return histories.map(
+        history ->
+            SearchStockHistoryResponse.builder()
+                .productId(history.getProductId())
+                .productCode(history.getProductInfo().getProductCode())
+                .productName(history.getProductInfo().getProductName())
+                .vendorId(history.getVendor().getId())
+                .vendorName(history.getVendor().getName())
+                .hubId(history.getHubId())
+                .type(history.getType())
+                .refId(history.getRefId())
+                .beforeQuantity(history.getBeforeQuantity())
+                .afterQuantity(history.getAfterQuantity())
+                .createdAt(TimeUtil.toLocalDateTime(history.getCreatedAt()))
+                .build());
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/application/event/StockChangeEventHandler.java
+++ b/src/main/java/followMe/hub_server/stock/application/event/StockChangeEventHandler.java
@@ -1,0 +1,50 @@
+package followMe.hub_server.stock.application.event;
+
+import followMe.hub_server.stock.domain.HubStockHistory;
+import followMe.hub_server.stock.domain.HubStockHistoryRepository;
+import followMe.hub_server.stock.domain.event.StockChangedEvent;
+import followMe.hub_server.stock.domain.event.StockOrderEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StockChangeEventHandler {
+  private final HubStockHistoryRepository historyRepository;
+
+  // TODO: retry 도입 시, 보상 행위 필요. 현재는 이력 저장 실패 시 무시
+  @Async
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void handleStockChangedEvent(StockChangedEvent event) {
+    historyRepository.save(
+        HubStockHistory.record(
+            event.getHubStock(),
+            event.getType(),
+            event.getRefId(),
+            event.getBeforeQuantity(),
+            event.getAfterQuantity()));
+    log.info("Stock changed Record");
+  }
+
+  @Async
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void handleOrderStockChangedEvent(StockOrderEvent event) {
+    historyRepository.save(
+        HubStockHistory.record(
+            event.getHubStock(),
+            event.getType(),
+            event.getOrderId(),
+            event.getBeforeQuantity(),
+            event.getAfterQuantity()));
+    log.info("Order Stock changed Record");
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/application/service/HubStockService.java
+++ b/src/main/java/followMe/hub_server/stock/application/service/HubStockService.java
@@ -1,0 +1,167 @@
+package followMe.hub_server.stock.application.service;
+
+import followMe.hub_server.stock.application.dto.CreateHubStockDto.CreateHubStockRequest;
+import followMe.hub_server.stock.application.dto.CreateHubStockDto.CreateHubStockResponse;
+import followMe.hub_server.stock.application.dto.DeleteHubStockDto.DeleteHubStockRequest;
+import followMe.hub_server.stock.application.dto.OrderHubStockDto.OrderHubStockRequest;
+import followMe.hub_server.stock.application.dto.OrderHubStockDto.OrderHubStockRequest.Product;
+import followMe.hub_server.stock.application.dto.OrderHubStockDto.OrderHubStockResponse;
+import followMe.hub_server.stock.application.dto.UpdateHubStockDto.UpdateHubStockRequest;
+import followMe.hub_server.stock.application.dto.UpdateHubStockDto.UpdateHubStockResponse;
+import followMe.hub_server.stock.domain.HubStock;
+import followMe.hub_server.stock.domain.HubStockRepository;
+import followMe.hub_server.stock.domain.exception.detail.DuplicatedOrderException;
+import followMe.hub_server.stock.domain.exception.detail.DuplicatedProductException;
+import followMe.hub_server.stock.domain.exception.detail.NotFoundProductException;
+import followMe.hub_server.stock.domain.service.HubExistenceChecker;
+import followMe.hub_server.stock.domain.service.PermissionChecker;
+import followMe.hub_server.stock.domain.service.VendorProductExistenceChecker;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class HubStockService {
+  private final HubStockRepository hubStockRepository;
+
+  private final PermissionChecker permissionChecker;
+  private final HubExistenceChecker hubExistenceChecker;
+  private final VendorProductExistenceChecker vendorProductExistenceChecker;
+
+  /*
+   * 상품 재고 생성
+   * - 이미 있는 상품을 중복하여 재고 생성 시 예외 반환
+   */
+  public CreateHubStockResponse create(CreateHubStockRequest request, UUID requesterId) {
+
+    boolean isExistProduct = hubStockRepository.existsById(request.getProductId());
+    if (isExistProduct) {
+      throw new DuplicatedProductException();
+    }
+
+    HubStock saved =
+        hubStockRepository.save(
+            HubStock.create(
+                requesterId,
+                request.getProductId(),
+                request.getProductCode(),
+                request.getProductName(),
+                request.getHubId(),
+                request.getVendorId(),
+                request.getVendorName(),
+                request.getQuantity(),
+                permissionChecker,
+                hubExistenceChecker,
+                vendorProductExistenceChecker));
+
+    return CreateHubStockResponse.from(saved);
+  }
+
+  /*
+   * 상품 재고 단건 수정
+   * - 관리 목적의 상품 재고 수정
+   */
+  public UpdateHubStockResponse update(
+      UpdateHubStockRequest request, UUID productId, UUID requesterId) {
+
+    HubStock stock =
+        hubStockRepository.findById(productId).orElseThrow(NotFoundProductException::new);
+
+    // 추후 리팩토링 필요
+    if (HubStock.isDecreaseType(request.getType())) {
+      stock.decreaseQuantity(
+          requesterId, request.getQuantity(), request.getType(), permissionChecker);
+
+    } else if (HubStock.isIncreaseType(request.getType())) {
+      stock.increaseQuantity(
+          requesterId, request.getQuantity(), request.getType(), permissionChecker);
+    }
+
+    return UpdateHubStockResponse.from(stock);
+  }
+
+  /*
+   * 주문으로 인한 재고 수정
+   */
+  public OrderHubStockResponse order(OrderHubStockRequest request, UUID requesterId) {
+    List<Product> products = request.getProducts();
+    checkOrderDuplicateIds(products);
+
+    Map<UUID, Integer> requestMap =
+        products.stream().collect(Collectors.toMap(Product::getId, Product::getQuantity));
+
+    Collection<HubStock> stocks = hubStockRepository.findAllByProductIdIn(requestMap.keySet());
+    UUID orderId = request.getOrderId();
+
+    // 조회한 상품 갯수와, 요청 갯수가 맞지않는 경우 -> DB에 존재하지않는 상품 존재
+    if (stocks.size() != requestMap.size()) {
+      throw new NotFoundProductException();
+    }
+
+    for (HubStock stock : stocks) {
+      UUID p = stock.getProductId();
+      Integer requestQuantity = requestMap.get(p);
+      stock.orderDecreaseQuantity(orderId, requestQuantity);
+    }
+
+    return OrderHubStockResponse.from(orderId, Instant.now());
+  }
+
+  /*
+   * 주문 취소 인한 재고 롤백
+   * TODO: 주문 요청, 취소 같은 로직. 추후 리팩토링 필요
+   */
+  public OrderHubStockResponse orderCancel(OrderHubStockRequest request, UUID requesterId) {
+    List<Product> products = request.getProducts();
+    checkOrderDuplicateIds(products);
+
+    Map<UUID, Integer> requestMap =
+        products.stream().collect(Collectors.toMap(Product::getId, Product::getQuantity));
+
+    Collection<HubStock> stocks = hubStockRepository.findAllByProductIdIn(requestMap.keySet());
+    UUID orderId = request.getOrderId();
+
+    if (stocks.size() != requestMap.size()) {
+      throw new NotFoundProductException();
+    }
+
+    for (HubStock stock : stocks) {
+      UUID p = stock.getProductId();
+      Integer requestQuantity = requestMap.get(p);
+      stock.orderCancelQuantity(orderId, requestQuantity);
+    }
+
+    return OrderHubStockResponse.from(orderId, Instant.now());
+  }
+
+  /*
+   * 상품 재고 삭제
+   */
+  public void delete(DeleteHubStockRequest request, UUID productId, UUID requesterId) {
+
+    HubStock stock =
+        hubStockRepository.findById(productId).orElseThrow(NotFoundProductException::new);
+
+    stock.delete(requesterId, request.getType(), permissionChecker);
+  }
+
+  /*
+   * 중복 상품 요청 검사
+   */
+  private void checkOrderDuplicateIds(List<Product> products) {
+    long uniqueCount = products.stream().map(Product::getId).distinct().count();
+    if (uniqueCount != products.size()) {
+      throw new DuplicatedOrderException();
+    }
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/application/service/QueryHubStockHistoryService.java
+++ b/src/main/java/followMe/hub_server/stock/application/service/QueryHubStockHistoryService.java
@@ -1,0 +1,24 @@
+package followMe.hub_server.stock.application.service;
+
+import followMe.hub_server.stock.application.dto.history.SearchStockHistoryResponse;
+import followMe.hub_server.stock.domain.HubStockHistory;
+import followMe.hub_server.stock.domain.HubStockHistoryRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class QueryHubStockHistoryService {
+  private final HubStockHistoryRepository historyRepository;
+
+  public Page<SearchStockHistoryResponse> getStockHistory(UUID productId, Pageable pageable) {
+    Page<HubStockHistory> histories = historyRepository.findByProductId(productId, pageable);
+
+    return SearchStockHistoryResponse.from(histories);
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/application/service/QueryHubStockService.java
+++ b/src/main/java/followMe/hub_server/stock/application/service/QueryHubStockService.java
@@ -1,0 +1,58 @@
+package followMe.hub_server.stock.application.service;
+
+import followMe.hub_server.stock.application.dto.SearchCondition;
+import followMe.hub_server.stock.application.dto.SearchProductIdsRequest;
+import followMe.hub_server.stock.application.dto.SearchResponse;
+import followMe.hub_server.stock.domain.HubStock;
+import followMe.hub_server.stock.domain.HubStockRepository;
+import followMe.hub_server.stock.domain.exception.detail.InvalidSearchCondition;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class QueryHubStockService {
+  private final HubStockRepository hubStockRepository;
+
+  // TODO: Query DSL 도입 시 수정
+  public Page<SearchResponse> searchHubStock(SearchCondition condition, Pageable pageable) {
+
+    if (Objects.isNull(condition)) {
+      return SearchResponse.from(hubStockRepository.findAll(pageable));
+    }
+    if (Objects.nonNull(condition.getProductId())) {
+      return SearchResponse.from(
+          hubStockRepository.findAllByProductId(condition.getProductId(), pageable));
+    }
+    if (Objects.nonNull(condition.getHubId())) {
+      return SearchResponse.from(hubStockRepository.findAllByHubId(condition.getHubId(), pageable));
+    }
+    if (Objects.nonNull(condition.getVendorId())) {
+      return SearchResponse.from(
+          hubStockRepository.findAllByVendor_Id(condition.getVendorId(), pageable));
+    }
+
+    throw new InvalidSearchCondition();
+  }
+
+  public Page<SearchResponse> searchHubStock(SearchProductIdsRequest request, Pageable pageable) {
+
+    Set<UUID> ids =
+        request.getProducts().stream()
+            .map(SearchProductIdsRequest.RequestProduct::getId)
+            .collect(Collectors.toSet());
+    Page<HubStock> stocks = hubStockRepository.findAllByProductIdIn(ids, pageable);
+
+    return SearchResponse.from(stocks);
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/domain/HubStock.java
+++ b/src/main/java/followMe/hub_server/stock/domain/HubStock.java
@@ -1,0 +1,244 @@
+package followMe.hub_server.stock.domain;
+
+import com.followMe.common.entity.BaseAudit;
+import followMe.hub_server.stock.domain.event.StockChangedEvent;
+import followMe.hub_server.stock.domain.event.StockOrderEvent;
+import followMe.hub_server.stock.domain.exception.StockErrorCode;
+import followMe.hub_server.stock.domain.exception.detail.*;
+import followMe.hub_server.stock.domain.service.HubExistenceChecker;
+import followMe.hub_server.stock.domain.service.OrderValidateChecker;
+import followMe.hub_server.stock.domain.service.PermissionChecker;
+import followMe.hub_server.stock.domain.service.VendorProductExistenceChecker;
+import followMe.hub_server.stock.domain.vo.ProductInfo;
+import followMe.hub_server.stock.domain.vo.Vendor;
+import followMe.hub_server.stock.infrastructure.event.Events;
+import jakarta.persistence.*;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Getter
+@Entity
+@Table(name = "p_hub_stock")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+public class HubStock extends BaseAudit {
+  private static final Set<Type> DECREASE_TYPES = Set.of(Type.ADJUST_LOSS, Type.OUTBOUND);
+  private static final Set<Type> INCREASE_TYPES =
+      Set.of(Type.INBOUND, Type.RETURN_IN, Type.ORDER_CANCELED);
+  private static final Set<Type> DELETED_TYPES = Set.of(Type.DISCONTINUED);
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(name = "product_id", nullable = false)
+  private UUID productId;
+
+  @Embedded private ProductInfo productInfo;
+
+  @Embedded private Vendor vendor;
+
+  @Column(name = "hubId", nullable = false)
+  private UUID hubId;
+
+  @Column(nullable = false)
+  Integer quantity;
+
+  @Version Long version;
+
+  @Builder(access = AccessLevel.PRIVATE)
+  private HubStock(
+      UUID productId, ProductInfo productInfo, UUID hubId, Vendor vendor, Integer quantity) {
+    this.productId = productId;
+    this.productInfo = productInfo;
+    this.hubId = hubId;
+    this.vendor = vendor;
+    this.quantity = quantity;
+  }
+
+  /*
+   * 재고 생성 시 검증
+   * 0. 옳바른 초기 재고 수량인지 검증
+   * 1. 허브 존재 유무 검증
+   * 2. 재고 등록 권한 검증 - 마스터, 허브 관리자(본인 허브)
+   * 3. 업체 상품 검증(허브가 관리하는 업체의 상품인지)
+   */
+  public static HubStock create(
+      UUID requesterId,
+      UUID productId,
+      String productCode,
+      String productName,
+      UUID hubId,
+      UUID vendorId,
+      String vendorName,
+      Integer quantity,
+      PermissionChecker permissionChecker,
+      HubExistenceChecker hubExistenceChecker,
+      VendorProductExistenceChecker vendorProductExistenceChecker) {
+
+    checkValidateCreateQuantity(quantity);
+    checkHubExistence(hubId, hubExistenceChecker);
+    checkCreatePermission(requesterId, hubId, permissionChecker);
+    checkVendorProductExistence(vendorId, productId, hubId, vendorProductExistenceChecker);
+
+    HubStock stock =
+        HubStock.builder()
+            .productId(productId)
+            .productInfo(ProductInfo.of(productCode, productName))
+            .hubId(hubId)
+            .vendor(Vendor.of(vendorId, vendorName))
+            .quantity(quantity)
+            .build();
+
+    Events.publish(StockChangedEvent.inboundOf(stock, 0, quantity));
+    return stock;
+  }
+
+  /*
+   * 재고 감소 시 검증
+   * 1. 재고 감소 타입(유형) 검증 & 남은 재고 검증 (현재 재고 > 감소 요청)
+   * 3. 재고 감소 권한 검증(주문이 아닌 감소는 마스터, 허브 관리자(본인 허브))
+   */
+  public void decreaseQuantity(
+      UUID requesterId, Integer amount, Type cause, PermissionChecker permissionChecker) {
+
+    checkValidateDecrease(amount, cause);
+    checkUpdatePermission(requesterId, this.hubId, permissionChecker);
+
+    Integer before = this.quantity;
+    this.quantity -= amount;
+    Events.publish(StockChangedEvent.decreaseOf(this, cause, before, this.quantity));
+  }
+
+  /*
+   * 주문 재고 감소 시 검증
+   * 1. 재고 감소 타입(유형) 검증 & 남은 재고 검증 (현재 재고 > 감소 요청)
+   * 2. orderId 유효성 검증
+   */
+  public void orderDecreaseQuantity(
+      UUID requesterId, UUID orderId, OrderValidateChecker orderValidateChecker) {
+
+    checkValidateDecrease(quantity, Type.OUTBOUND);
+    checkValidateOrder(requesterId, orderId, orderValidateChecker);
+
+    Integer before = this.quantity;
+    this.quantity -= quantity;
+    Events.publish(StockOrderEvent.of(this, orderId, before, this.quantity));
+  }
+
+  /*
+   * 재고 증가 시 검증
+   * 1. 재고 증가 타입(유형) 검증
+   * 2. 재고 증가 권한 검증(주문이 아닌 감소는 마스터, 허브 관리자(본인 허브))
+   */
+  public void increaseQuantity(
+      UUID requesterId, Integer amount, Type cause, PermissionChecker permissionChecker) {
+
+    checkValidateIncrease(amount, cause);
+    checkUpdatePermission(requesterId, this.hubId, permissionChecker);
+
+    Integer before = this.quantity;
+    this.quantity += amount;
+    Events.publish(StockChangedEvent.increaseOf(this, cause, before, this.quantity));
+  }
+
+  /*
+   * 재고 삭제 시 검증
+   * 1. 재고 수량, 타입 검증(재고가 남아있으면 삭제 불가)
+   * 2. 재고 삭제 권한 검증
+   */
+  public void delete(UUID requesterId, Type cause, PermissionChecker permissionChecker) {
+
+    checkValidateDeleteStock(cause);
+    checkDeletePermission(requesterId, this.hubId, permissionChecker);
+
+    this.softDelete();
+    Events.publish(StockChangedEvent.deleteOf(this));
+  }
+
+  private static void checkValidateCreateQuantity(Integer quantity) {
+    if (Objects.isNull(quantity) || quantity < 0) {
+      throw new InvalidQuantityException(StockErrorCode.STOCK_INVALID_INIT_QUANTITY);
+    }
+  }
+
+  private static void checkCreatePermission(
+      UUID requesterId, UUID hubId, PermissionChecker permissionChecker) {
+    final Set<UserRole> permission = Set.of(UserRole.MASTER, UserRole.HUB);
+    if (!permissionChecker.hasCreatePermission(requesterId, hubId)) {
+      throw new NoPermissionException(StockErrorCode.STOCK_REGISTER_FORBIDDEN);
+    }
+  }
+
+  private void checkUpdatePermission(
+      UUID requesterId, UUID hubId, PermissionChecker permissionChecker) {
+    if (!permissionChecker.hasUpdatePermission(requesterId, hubId)) {
+      throw new NoPermissionException(StockErrorCode.STOCK_UPDATE_FORBIDDEN);
+    }
+  }
+
+  private void checkDeletePermission(
+      UUID requesterId, UUID hubId, PermissionChecker permissionChecker) {
+    if (!permissionChecker.hasDeletePermission(requesterId, hubId)) {
+      throw new NoPermissionException(StockErrorCode.STOCK_DELETED_FORBIDDEN);
+    }
+  }
+
+  private static void checkHubExistence(UUID hubId, HubExistenceChecker hubExistenceChecker) {
+    if (!hubExistenceChecker.hasHub(hubId)) {
+      throw new NotFoundHubException();
+    }
+  }
+
+  private static void checkVendorProductExistence(
+      UUID vendorId,
+      UUID productId,
+      UUID hubId,
+      VendorProductExistenceChecker vendorProductExistenceChecker) {
+    if (!vendorProductExistenceChecker.hasVendorProduct(vendorId, productId, hubId)) {
+      throw new InvalidProductException();
+    }
+  }
+
+  private void checkValidateDecrease(Integer amount, Type cause) {
+    checkValidAmount(amount);
+    if (!DECREASE_TYPES.contains(cause)) {
+      throw new InvalidStockTypeException(StockErrorCode.STOCK_NOT_DECREASE_TYPE);
+    }
+    if (this.quantity < amount) {
+      throw new InvalidQuantityException(StockErrorCode.STOCK_INSUFFICIENT);
+    }
+  }
+
+  private void checkValidateIncrease(Integer amount, Type cause) {
+    checkValidAmount(amount);
+    if (!INCREASE_TYPES.contains(cause)) {
+      throw new InvalidStockTypeException(StockErrorCode.STOCK_NOT_INCREASE_TYPE);
+    }
+  }
+
+  private void checkValidateOrder(
+      UUID requesterId, UUID orderId, OrderValidateChecker orderValidateChecker) {
+    // 현재 주문과 재고 감소 요청은 동기식으로 동작하므로 추가 유효성 검사는 하지않음
+    return;
+  }
+
+  private void checkValidateDeleteStock(Type cause) {
+    if (!DELETED_TYPES.contains(cause)) {
+      throw new InvalidStockTypeException(StockErrorCode.STOCK_NOT_DELETED_TYPE);
+    }
+    if (this.quantity > 0) {
+      throw new InvalidQuantityException(StockErrorCode.STOCK_EXISTS);
+    }
+  }
+
+  private void checkValidAmount(Integer amount) {
+    if (Objects.isNull(amount) || (amount < 0)) {
+      throw new InvalidQuantityException();
+    }
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/domain/HubStock.java
+++ b/src/main/java/followMe/hub_server/stock/domain/HubStock.java
@@ -120,13 +120,13 @@ public class HubStock extends BaseAudit {
    * 2. orderId 유효성 검증
    */
   public void orderDecreaseQuantity(
-      UUID requesterId, UUID orderId, OrderValidateChecker orderValidateChecker) {
+      UUID requesterId, UUID orderId, Integer amount, OrderValidateChecker orderValidateChecker) {
 
-    checkValidateDecrease(quantity, Type.OUTBOUND);
+    checkValidateDecrease(amount, Type.OUTBOUND);
     checkValidateOrder(requesterId, orderId, orderValidateChecker);
 
     Integer before = this.quantity;
-    this.quantity -= quantity;
+    this.quantity -= amount;
     Events.publish(StockOrderEvent.of(this, orderId, before, this.quantity));
   }
 

--- a/src/main/java/followMe/hub_server/stock/domain/HubStock.java
+++ b/src/main/java/followMe/hub_server/stock/domain/HubStock.java
@@ -117,17 +117,25 @@ public class HubStock extends BaseAudit {
   /*
    * 주문 재고 감소 시 검증
    * 1. 재고 감소 타입(유형) 검증 & 남은 재고 검증 (현재 재고 > 감소 요청)
-   * 2. orderId 유효성 검증
+   * 2. TODO: (제외)orderId 유효성 검증, 필요하다면 application 영역에서 수행.
+   *     도메인에서 치리시 N건의 요청에 N건 통신 발생
    */
-  public void orderDecreaseQuantity(
-      UUID requesterId, UUID orderId, Integer amount, OrderValidateChecker orderValidateChecker) {
+  public void orderDecreaseQuantity(UUID orderId, Integer amount) {
 
     checkValidateDecrease(amount, Type.OUTBOUND);
-    checkValidateOrder(requesterId, orderId, orderValidateChecker);
 
     Integer before = this.quantity;
     this.quantity -= amount;
     Events.publish(StockOrderEvent.of(this, orderId, before, this.quantity));
+  }
+
+  public void orderCancelQuantity(UUID orderId, Integer amount) {
+
+    checkValidateIncrease(amount, Type.ORDER_CANCELED);
+
+    Integer before = this.quantity;
+    this.quantity += amount;
+    Events.publish(StockOrderEvent.cancelOf(this, orderId, before, this.quantity));
   }
 
   /*
@@ -158,6 +166,20 @@ public class HubStock extends BaseAudit {
 
     this.softDelete();
     Events.publish(StockChangedEvent.deleteOf(this));
+  }
+
+  public static boolean isDecreaseType(Type type) {
+    if (Objects.isNull(type)) {
+      throw new InvalidStockTypeException(StockErrorCode.STOCK_TYPE_NULL);
+    }
+    return DECREASE_TYPES.contains(type);
+  }
+
+  public static boolean isIncreaseType(Type type) {
+    if (Objects.isNull(type)) {
+      throw new InvalidStockTypeException(StockErrorCode.STOCK_TYPE_NULL);
+    }
+    return INCREASE_TYPES.contains(type);
   }
 
   private static void checkValidateCreateQuantity(Integer quantity) {

--- a/src/main/java/followMe/hub_server/stock/domain/HubStock.java
+++ b/src/main/java/followMe/hub_server/stock/domain/HubStock.java
@@ -42,7 +42,7 @@ public class HubStock extends BaseAudit {
 
   @Embedded private Vendor vendor;
 
-  @Column(name = "hubId", nullable = false)
+  @Column(name = "hub_id", nullable = false)
   private UUID hubId;
 
   @Column(nullable = false)

--- a/src/main/java/followMe/hub_server/stock/domain/HubStockHistory.java
+++ b/src/main/java/followMe/hub_server/stock/domain/HubStockHistory.java
@@ -1,0 +1,79 @@
+package followMe.hub_server.stock.domain;
+
+import com.followMe.common.entity.BaseAudit;
+import followMe.hub_server.stock.domain.vo.ProductInfo;
+import followMe.hub_server.stock.domain.vo.Vendor;
+import jakarta.persistence.*;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Getter
+@Entity
+@Table(name = "p_hub_stock_history")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+public class HubStockHistory extends BaseAudit {
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(nullable = false)
+  private UUID historyId;
+
+  @Column(nullable = false)
+  private UUID productId;
+
+  @Embedded private ProductInfo productInfo;
+
+  @Embedded private Vendor vendor;
+
+  @Column(nullable = false)
+  private UUID hubId;
+
+  @Column(nullable = false)
+  private Type type;
+
+  private UUID refId;
+
+  @Column(nullable = false)
+  private Integer beforeQuantity;
+
+  @Column(nullable = false)
+  private Integer afterQuantity;
+
+  @Builder(access = AccessLevel.PRIVATE)
+  public HubStockHistory(
+      UUID productId,
+      ProductInfo productInfo,
+      Vendor vendor,
+      UUID hubId,
+      Type type,
+      UUID refId,
+      Integer beforeQuantity,
+      Integer afterQuantity) {
+    this.productId = productId;
+    this.productInfo = productInfo;
+    this.vendor = vendor;
+    this.hubId = hubId;
+    this.type = type;
+    this.refId = refId;
+    this.beforeQuantity = beforeQuantity;
+    this.afterQuantity = afterQuantity;
+  }
+
+  public static HubStockHistory recode(
+      HubStock hubStock, Type type, UUID refId, Integer beforeQuantity, Integer afterQuantity) {
+    return HubStockHistory.builder()
+        .productId(hubStock.getProductId())
+        .productInfo(hubStock.getProductInfo())
+        .vendor(hubStock.getVendor())
+        .hubId(hubStock.getHubId())
+        .type(type)
+        .refId(refId)
+        .beforeQuantity(beforeQuantity)
+        .afterQuantity(afterQuantity)
+        .build();
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/domain/HubStockHistory.java
+++ b/src/main/java/followMe/hub_server/stock/domain/HubStockHistory.java
@@ -19,28 +19,29 @@ import org.hibernate.annotations.SQLRestriction;
 public class HubStockHistory extends BaseAudit {
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
-  @Column(nullable = false)
+  @Column(name = "history_id", nullable = false)
   private UUID historyId;
 
-  @Column(nullable = false)
+  @Column(name = "product_id", nullable = false)
   private UUID productId;
 
   @Embedded private ProductInfo productInfo;
 
   @Embedded private Vendor vendor;
 
-  @Column(nullable = false)
+  @Column(name = "hub_id", nullable = false)
   private UUID hubId;
 
   @Column(nullable = false)
   private Type type;
 
+  @Column(name = "ref_id")
   private UUID refId;
 
-  @Column(nullable = false)
+  @Column(name = "before_quantity", nullable = false)
   private Integer beforeQuantity;
 
-  @Column(nullable = false)
+  @Column(name = "after_quantity", nullable = false)
   private Integer afterQuantity;
 
   @Builder(access = AccessLevel.PRIVATE)

--- a/src/main/java/followMe/hub_server/stock/domain/HubStockHistory.java
+++ b/src/main/java/followMe/hub_server/stock/domain/HubStockHistory.java
@@ -63,7 +63,7 @@ public class HubStockHistory extends BaseAudit {
     this.afterQuantity = afterQuantity;
   }
 
-  public static HubStockHistory recode(
+  public static HubStockHistory record(
       HubStock hubStock, Type type, UUID refId, Integer beforeQuantity, Integer afterQuantity) {
     return HubStockHistory.builder()
         .productId(hubStock.getProductId())

--- a/src/main/java/followMe/hub_server/stock/domain/HubStockHistoryRepository.java
+++ b/src/main/java/followMe/hub_server/stock/domain/HubStockHistoryRepository.java
@@ -1,5 +1,11 @@
 package followMe.hub_server.stock.domain;
 
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface HubStockHistoryRepository {
   HubStockHistory save(HubStockHistory history);
+
+  Page<HubStockHistory> findByProductId(UUID productId, Pageable pageable);
 }

--- a/src/main/java/followMe/hub_server/stock/domain/HubStockHistoryRepository.java
+++ b/src/main/java/followMe/hub_server/stock/domain/HubStockHistoryRepository.java
@@ -1,0 +1,5 @@
+package followMe.hub_server.stock.domain;
+
+public interface HubStockHistoryRepository {
+  HubStockHistory save(HubStockHistory history);
+}

--- a/src/main/java/followMe/hub_server/stock/domain/HubStockRepository.java
+++ b/src/main/java/followMe/hub_server/stock/domain/HubStockRepository.java
@@ -1,0 +1,29 @@
+package followMe.hub_server.stock.domain;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface HubStockRepository {
+
+  HubStock save(HubStock hubStock);
+
+  Optional<HubStock> findById(UUID productId);
+
+  boolean existsById(UUID productId);
+
+  Collection<HubStock> findAllByProductIdIn(Collection<UUID> productIds);
+
+  // Query DSL 도입시 분리
+  Page<HubStock> findAllByProductId(UUID productId, Pageable pageable);
+
+  Page<HubStock> findAllByHubId(UUID hubId, Pageable pageable);
+
+  Page<HubStock> findAllByVendor_Id(UUID vendorId, Pageable pageable);
+
+  Page<HubStock> findAll(Pageable pageable);
+
+  Page<HubStock> findAllByProductIdIn(Collection<UUID> productIds, Pageable pageable);
+}

--- a/src/main/java/followMe/hub_server/stock/domain/Type.java
+++ b/src/main/java/followMe/hub_server/stock/domain/Type.java
@@ -1,0 +1,10 @@
+package followMe.hub_server.stock.domain;
+
+public enum Type {
+  INBOUND,
+  OUTBOUND,
+  ADJUST_LOSS,
+  RETURN_IN,
+  DISCONTINUED,
+  ORDER_CANCELED,
+}

--- a/src/main/java/followMe/hub_server/stock/domain/UserRole.java
+++ b/src/main/java/followMe/hub_server/stock/domain/UserRole.java
@@ -1,0 +1,8 @@
+package followMe.hub_server.stock.domain;
+
+public enum UserRole {
+  MASTER,
+  HUB,
+  DELIVERY,
+  VENDOR;
+}

--- a/src/main/java/followMe/hub_server/stock/domain/event/StockChangedEvent.java
+++ b/src/main/java/followMe/hub_server/stock/domain/event/StockChangedEvent.java
@@ -1,0 +1,64 @@
+package followMe.hub_server.stock.domain.event;
+
+import followMe.hub_server.stock.domain.HubStock;
+import followMe.hub_server.stock.domain.Type;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class StockChangedEvent {
+  private HubStock hubStock;
+  private Type type;
+  private UUID refId;
+  private Integer beforeQuantity;
+  private Integer afterQuantity;
+
+  public static StockChangedEvent inboundOf(
+      HubStock hubStock, Integer beforeQuantity, Integer afterQuantity) {
+    return StockChangedEvent.builder()
+        .hubStock(hubStock)
+        .type(Type.INBOUND)
+        .refId(null)
+        .beforeQuantity(beforeQuantity)
+        .afterQuantity(afterQuantity)
+        .build();
+  }
+
+  public static StockChangedEvent decreaseOf(
+      HubStock hubStock, Type type, Integer beforeQuantity, Integer afterQuantity) {
+    return StockChangedEvent.builder()
+        .hubStock(hubStock)
+        .type(type)
+        .refId(null)
+        .beforeQuantity(beforeQuantity)
+        .afterQuantity(afterQuantity)
+        .build();
+  }
+
+  public static StockChangedEvent increaseOf(
+      HubStock hubStock, Type type, Integer beforeQuantity, Integer afterQuantity) {
+    return StockChangedEvent.builder()
+        .hubStock(hubStock)
+        .type(type)
+        .refId(null)
+        .beforeQuantity(beforeQuantity)
+        .afterQuantity(afterQuantity)
+        .build();
+  }
+
+  public static StockChangedEvent deleteOf(HubStock hubStock) {
+    return StockChangedEvent.builder()
+        .hubStock(hubStock)
+        .type(Type.DISCONTINUED)
+        .refId(null)
+        .beforeQuantity(0)
+        .afterQuantity(0)
+        .build();
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/domain/event/StockOrderEvent.java
+++ b/src/main/java/followMe/hub_server/stock/domain/event/StockOrderEvent.java
@@ -29,4 +29,15 @@ public class StockOrderEvent {
         .afterQuantity(afterQuantity)
         .build();
   }
+
+  public static StockOrderEvent cancelOf(
+      HubStock hubStock, UUID orderId, Integer beforeQuantity, Integer afterQuantity) {
+    return StockOrderEvent.builder()
+        .hubStock(hubStock)
+        .type(Type.ORDER_CANCELED)
+        .orderId(orderId)
+        .beforeQuantity(beforeQuantity)
+        .afterQuantity(afterQuantity)
+        .build();
+  }
 }

--- a/src/main/java/followMe/hub_server/stock/domain/event/StockOrderEvent.java
+++ b/src/main/java/followMe/hub_server/stock/domain/event/StockOrderEvent.java
@@ -1,0 +1,32 @@
+package followMe.hub_server.stock.domain.event;
+
+import followMe.hub_server.stock.domain.HubStock;
+import followMe.hub_server.stock.domain.Type;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class StockOrderEvent {
+  private HubStock hubStock;
+  private Type type;
+  private UUID orderId;
+  private Integer beforeQuantity;
+  private Integer afterQuantity;
+
+  public static StockOrderEvent of(
+      HubStock hubStock, UUID orderId, Integer beforeQuantity, Integer afterQuantity) {
+    return StockOrderEvent.builder()
+        .hubStock(hubStock)
+        .type(Type.OUTBOUND)
+        .orderId(orderId)
+        .beforeQuantity(beforeQuantity)
+        .afterQuantity(afterQuantity)
+        .build();
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/domain/exception/StockErrorCode.java
+++ b/src/main/java/followMe/hub_server/stock/domain/exception/StockErrorCode.java
@@ -1,0 +1,31 @@
+package followMe.hub_server.stock.domain.exception;
+
+import com.followMe.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum StockErrorCode implements ErrorCode {
+  STOCK_INVALID_QUANTITY("STOCK_002", "요청한 수량이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+  STOCK_INVALID_INIT_QUANTITY("STOCK_003", "초기 물품 수량은 0보다 크거나 같아야 합니다.", HttpStatus.BAD_REQUEST),
+  STOCK_INSUFFICIENT("STOCK_004", "재고가 충분하지 않습니다.", HttpStatus.CONFLICT),
+  STOCK_NOT_DECREASE_TYPE("STOCK_005", "해당 타입은 재고 감소 유형이 이닙니다.", HttpStatus.BAD_REQUEST),
+  STOCK_NOT_INCREASE_TYPE("STOCK_006", "해당 타입은 재고 증가 유형이 아닙니다.", HttpStatus.BAD_REQUEST),
+  STOCK_NOT_DELETED_TYPE("STOCK_007", "해당 타입은 재고 삭제 유형이 아닙니다.", HttpStatus.BAD_REQUEST),
+  STOCK_EXISTS("STOCK_008", "재고가 남아있어 요청을 처리할 수 없습니다.", HttpStatus.BAD_REQUEST),
+
+  PRODUCT_INVALID_INFO("STOCK_009", "존재하지 않거나, 허브에서 관리하는 상품이 아닙니다.", HttpStatus.BAD_REQUEST),
+
+  STOCK_REGISTER_FORBIDDEN("STOCK_010", "재고를 등록할 권한이 부족합니다.", HttpStatus.FORBIDDEN),
+  STOCK_UPDATE_FORBIDDEN("STOCK_011", "재고를 수정할 권한이 부족합니다.", HttpStatus.FORBIDDEN),
+  STOCK_DELETED_FORBIDDEN("STOCK_012", "재고를 삭제할 권한이 부족합니다.", HttpStatus.FORBIDDEN),
+
+  HUB_NOT_FOUND("STOCK_020", "존재하지 않는 허브 입니다.", HttpStatus.NOT_FOUND),
+  ;
+
+  private final String code;
+  private final String message;
+  private final HttpStatus httpStatus;
+}

--- a/src/main/java/followMe/hub_server/stock/domain/exception/StockErrorCode.java
+++ b/src/main/java/followMe/hub_server/stock/domain/exception/StockErrorCode.java
@@ -15,14 +15,20 @@ public enum StockErrorCode implements ErrorCode {
   STOCK_NOT_INCREASE_TYPE("STOCK_006", "해당 타입은 재고 증가 유형이 아닙니다.", HttpStatus.BAD_REQUEST),
   STOCK_NOT_DELETED_TYPE("STOCK_007", "해당 타입은 재고 삭제 유형이 아닙니다.", HttpStatus.BAD_REQUEST),
   STOCK_EXISTS("STOCK_008", "재고가 남아있어 요청을 처리할 수 없습니다.", HttpStatus.BAD_REQUEST),
+  STOCK_TYPE_NULL("STOCK_008", "요청 재고 타입이 비어있습니다.", HttpStatus.BAD_REQUEST),
+  STOCK_INVALID_SEARCH_CONDITION("STOCK_009", "지원하지 않는 재고 검색 조건 입니다.", HttpStatus.BAD_REQUEST),
 
-  PRODUCT_INVALID_INFO("STOCK_009", "존재하지 않거나, 허브에서 관리하는 상품이 아닙니다.", HttpStatus.BAD_REQUEST),
-
-  STOCK_REGISTER_FORBIDDEN("STOCK_010", "재고를 등록할 권한이 부족합니다.", HttpStatus.FORBIDDEN),
-  STOCK_UPDATE_FORBIDDEN("STOCK_011", "재고를 수정할 권한이 부족합니다.", HttpStatus.FORBIDDEN),
-  STOCK_DELETED_FORBIDDEN("STOCK_012", "재고를 삭제할 권한이 부족합니다.", HttpStatus.FORBIDDEN),
+  PRODUCT_NOT_FOUND("STOCK_010", "존재하지 않는 상품 입니다.", HttpStatus.NOT_FOUND),
+  PRODUCT_INVALID_INFO("STOCK_011", "존재하지 않거나, 허브에서 관리하는 상품이 아닙니다.", HttpStatus.BAD_REQUEST),
+  PRODUCT_DUPLICATED("STOCK_012", "이미 해당 상품이 재고로 등록되어 있습니다.", HttpStatus.BAD_REQUEST),
 
   HUB_NOT_FOUND("STOCK_020", "존재하지 않는 허브 입니다.", HttpStatus.NOT_FOUND),
+
+  ORDER_DUPLICATED_PRODUCT("STOCK_030", "중복된 상품에 대한 재고 수정 요청이 존재합니다.", HttpStatus.BAD_REQUEST),
+
+  STOCK_REGISTER_FORBIDDEN("STOCK_100", "재고를 등록할 권한이 부족합니다.", HttpStatus.FORBIDDEN),
+  STOCK_UPDATE_FORBIDDEN("STOCK_101", "재고를 수정할 권한이 부족합니다.", HttpStatus.FORBIDDEN),
+  STOCK_DELETED_FORBIDDEN("STOCK_102", "재고를 삭제할 권한이 부족합니다.", HttpStatus.FORBIDDEN),
   ;
 
   private final String code;

--- a/src/main/java/followMe/hub_server/stock/domain/exception/StockException.java
+++ b/src/main/java/followMe/hub_server/stock/domain/exception/StockException.java
@@ -1,0 +1,19 @@
+package followMe.hub_server.stock.domain.exception;
+
+import com.followMe.common.exception.BusinessException;
+import com.followMe.common.exception.ErrorCode;
+
+public class StockException extends BusinessException {
+
+  public StockException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  public StockException(ErrorCode errorCode, String detailMessage) {
+    super(errorCode, detailMessage);
+  }
+
+  public StockException(ErrorCode errorCode, Throwable cause) {
+    super(errorCode, cause);
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/domain/exception/detail/DuplicatedOrderException.java
+++ b/src/main/java/followMe/hub_server/stock/domain/exception/detail/DuplicatedOrderException.java
@@ -1,0 +1,10 @@
+package followMe.hub_server.stock.domain.exception.detail;
+
+import followMe.hub_server.stock.domain.exception.StockErrorCode;
+import followMe.hub_server.stock.domain.exception.StockException;
+
+public class DuplicatedOrderException extends StockException {
+  public DuplicatedOrderException() {
+    super(StockErrorCode.ORDER_DUPLICATED_PRODUCT);
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/domain/exception/detail/DuplicatedProductException.java
+++ b/src/main/java/followMe/hub_server/stock/domain/exception/detail/DuplicatedProductException.java
@@ -1,0 +1,10 @@
+package followMe.hub_server.stock.domain.exception.detail;
+
+import followMe.hub_server.stock.domain.exception.StockErrorCode;
+import followMe.hub_server.stock.domain.exception.StockException;
+
+public class DuplicatedProductException extends StockException {
+  public DuplicatedProductException() {
+    super(StockErrorCode.PRODUCT_DUPLICATED);
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/domain/exception/detail/InvalidProductException.java
+++ b/src/main/java/followMe/hub_server/stock/domain/exception/detail/InvalidProductException.java
@@ -1,0 +1,10 @@
+package followMe.hub_server.stock.domain.exception.detail;
+
+import followMe.hub_server.stock.domain.exception.StockErrorCode;
+import followMe.hub_server.stock.domain.exception.StockException;
+
+public class InvalidProductException extends StockException {
+  public InvalidProductException() {
+    super(StockErrorCode.PRODUCT_INVALID_INFO);
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/domain/exception/detail/InvalidQuantityException.java
+++ b/src/main/java/followMe/hub_server/stock/domain/exception/detail/InvalidQuantityException.java
@@ -1,0 +1,14 @@
+package followMe.hub_server.stock.domain.exception.detail;
+
+import followMe.hub_server.stock.domain.exception.StockErrorCode;
+import followMe.hub_server.stock.domain.exception.StockException;
+
+public class InvalidQuantityException extends StockException {
+  public InvalidQuantityException() {
+    super(StockErrorCode.STOCK_INVALID_QUANTITY);
+  }
+
+  public InvalidQuantityException(StockErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/domain/exception/detail/InvalidSearchCondition.java
+++ b/src/main/java/followMe/hub_server/stock/domain/exception/detail/InvalidSearchCondition.java
@@ -1,0 +1,10 @@
+package followMe.hub_server.stock.domain.exception.detail;
+
+import followMe.hub_server.stock.domain.exception.StockErrorCode;
+import followMe.hub_server.stock.domain.exception.StockException;
+
+public class InvalidSearchCondition extends StockException {
+  public InvalidSearchCondition() {
+    super(StockErrorCode.STOCK_INVALID_SEARCH_CONDITION);
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/domain/exception/detail/InvalidStockTypeException.java
+++ b/src/main/java/followMe/hub_server/stock/domain/exception/detail/InvalidStockTypeException.java
@@ -1,0 +1,10 @@
+package followMe.hub_server.stock.domain.exception.detail;
+
+import followMe.hub_server.stock.domain.exception.StockErrorCode;
+import followMe.hub_server.stock.domain.exception.StockException;
+
+public class InvalidStockTypeException extends StockException {
+  public InvalidStockTypeException(StockErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/domain/exception/detail/NoPermissionException.java
+++ b/src/main/java/followMe/hub_server/stock/domain/exception/detail/NoPermissionException.java
@@ -1,0 +1,10 @@
+package followMe.hub_server.stock.domain.exception.detail;
+
+import followMe.hub_server.stock.domain.exception.StockErrorCode;
+import followMe.hub_server.stock.domain.exception.StockException;
+
+public class NoPermissionException extends StockException {
+  public NoPermissionException(StockErrorCode stockErrorCode) {
+    super(stockErrorCode);
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/domain/exception/detail/NotFoundHubException.java
+++ b/src/main/java/followMe/hub_server/stock/domain/exception/detail/NotFoundHubException.java
@@ -1,0 +1,10 @@
+package followMe.hub_server.stock.domain.exception.detail;
+
+import followMe.hub_server.stock.domain.exception.StockErrorCode;
+import followMe.hub_server.stock.domain.exception.StockException;
+
+public class NotFoundHubException extends StockException {
+  public NotFoundHubException() {
+    super(StockErrorCode.HUB_NOT_FOUND);
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/domain/exception/detail/NotFoundProductException.java
+++ b/src/main/java/followMe/hub_server/stock/domain/exception/detail/NotFoundProductException.java
@@ -1,0 +1,10 @@
+package followMe.hub_server.stock.domain.exception.detail;
+
+import followMe.hub_server.stock.domain.exception.StockErrorCode;
+import followMe.hub_server.stock.domain.exception.StockException;
+
+public class NotFoundProductException extends StockException {
+  public NotFoundProductException() {
+    super(StockErrorCode.PRODUCT_NOT_FOUND);
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/domain/service/HubExistenceChecker.java
+++ b/src/main/java/followMe/hub_server/stock/domain/service/HubExistenceChecker.java
@@ -1,0 +1,7 @@
+package followMe.hub_server.stock.domain.service;
+
+import java.util.UUID;
+
+public interface HubExistenceChecker {
+  boolean hasHub(UUID hubId);
+}

--- a/src/main/java/followMe/hub_server/stock/domain/service/OrderValidateChecker.java
+++ b/src/main/java/followMe/hub_server/stock/domain/service/OrderValidateChecker.java
@@ -1,0 +1,3 @@
+package followMe.hub_server.stock.domain.service;
+
+public interface OrderValidateChecker {}

--- a/src/main/java/followMe/hub_server/stock/domain/service/PermissionChecker.java
+++ b/src/main/java/followMe/hub_server/stock/domain/service/PermissionChecker.java
@@ -1,0 +1,11 @@
+package followMe.hub_server.stock.domain.service;
+
+import java.util.UUID;
+
+public interface PermissionChecker {
+  boolean hasCreatePermission(UUID requesterId, UUID hubId);
+
+  boolean hasUpdatePermission(UUID requesterId, UUID hubId);
+
+  boolean hasDeletePermission(UUID requesterId, UUID hubId);
+}

--- a/src/main/java/followMe/hub_server/stock/domain/service/VendorProductExistenceChecker.java
+++ b/src/main/java/followMe/hub_server/stock/domain/service/VendorProductExistenceChecker.java
@@ -1,0 +1,7 @@
+package followMe.hub_server.stock.domain.service;
+
+import java.util.UUID;
+
+public interface VendorProductExistenceChecker {
+  boolean hasVendorProduct(UUID vendorId, UUID productId, UUID hubId);
+}

--- a/src/main/java/followMe/hub_server/stock/domain/vo/ProductInfo.java
+++ b/src/main/java/followMe/hub_server/stock/domain/vo/ProductInfo.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProductInfo {
-  @Column(name = "product_Code", length = 50, nullable = false)
+  @Column(name = "product_code", length = 50, nullable = false)
   private String productCode;
 
   @Column(name = "product_name", nullable = false)

--- a/src/main/java/followMe/hub_server/stock/domain/vo/ProductInfo.java
+++ b/src/main/java/followMe/hub_server/stock/domain/vo/ProductInfo.java
@@ -1,0 +1,24 @@
+package followMe.hub_server.stock.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductInfo {
+  @Column(name = "product_Code", length = 50, nullable = false)
+  private String productCode;
+
+  @Column(name = "product_name", nullable = false)
+  private String productName;
+
+  public static ProductInfo of(String productCode, String productName) {
+    return new ProductInfo(productCode, productName);
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/domain/vo/Vendor.java
+++ b/src/main/java/followMe/hub_server/stock/domain/vo/Vendor.java
@@ -1,0 +1,25 @@
+package followMe.hub_server.stock.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Vendor {
+  @Column(name = "vendor_id", nullable = false)
+  private UUID id;
+
+  @Column(name = "vendor_name", nullable = false)
+  private String name;
+
+  public static Vendor of(UUID vendorId, String vendorName) {
+    return new Vendor(vendorId, vendorName);
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/infrastructure/client/checker/HubExistenceCheckerImpl.java
+++ b/src/main/java/followMe/hub_server/stock/infrastructure/client/checker/HubExistenceCheckerImpl.java
@@ -1,0 +1,18 @@
+package followMe.hub_server.stock.infrastructure.client.checker;
+
+import followMe.hub_server.stock.domain.service.HubExistenceChecker;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class HubExistenceCheckerImpl implements HubExistenceChecker {
+
+  //  private final HubFeignClient hubClient;
+
+  @Override
+  public boolean hasHub(UUID hubId) {
+    return true;
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/infrastructure/client/checker/PermissionCheckerImpl.java
+++ b/src/main/java/followMe/hub_server/stock/infrastructure/client/checker/PermissionCheckerImpl.java
@@ -1,0 +1,28 @@
+package followMe.hub_server.stock.infrastructure.client.checker;
+
+import followMe.hub_server.stock.domain.service.PermissionChecker;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PermissionCheckerImpl implements PermissionChecker {
+
+  //  private final UserFeignClient userFeignClient;
+
+  @Override
+  public boolean hasCreatePermission(UUID requesterId, UUID hubId) {
+    return true;
+  }
+
+  @Override
+  public boolean hasUpdatePermission(UUID requesterId, UUID hubId) {
+    return true;
+  }
+
+  @Override
+  public boolean hasDeletePermission(UUID requesterId, UUID hubId) {
+    return true;
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/infrastructure/client/checker/VendorProductExistenceCheckerImpl.java
+++ b/src/main/java/followMe/hub_server/stock/infrastructure/client/checker/VendorProductExistenceCheckerImpl.java
@@ -1,0 +1,18 @@
+package followMe.hub_server.stock.infrastructure.client.checker;
+
+import followMe.hub_server.stock.domain.service.VendorProductExistenceChecker;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class VendorProductExistenceCheckerImpl implements VendorProductExistenceChecker {
+
+  //  private final VendorFeignClient vendorFeignClient;
+
+  @Override
+  public boolean hasVendorProduct(UUID vendorId, UUID productId, UUID hubId) {
+    return true;
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/infrastructure/event/EventConfig.java
+++ b/src/main/java/followMe/hub_server/stock/infrastructure/event/EventConfig.java
@@ -1,0 +1,38 @@
+package followMe.hub_server.stock.infrastructure.event;
+
+import java.util.concurrent.Executor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.lang.Nullable;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor;
+
+// TODO: retry 설정 추가해야 됨
+@Configuration
+@EnableAsync
+@RequiredArgsConstructor
+public class EventConfig implements AsyncConfigurer {
+  private ApplicationContext ctx;
+
+  @Bean
+  public InitializingBean eventsInitializer() {
+    return () -> Events.setPublisher(ctx);
+  }
+
+  @Nullable
+  @Override
+  public Executor getAsyncExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(10);
+    executor.setMaxPoolSize(50);
+    executor.setQueueCapacity(100);
+    executor.setThreadNamePrefix("AsyncEvent-");
+    executor.initialize();
+    return new DelegatingSecurityContextAsyncTaskExecutor(executor);
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/infrastructure/event/Events.java
+++ b/src/main/java/followMe/hub_server/stock/infrastructure/event/Events.java
@@ -1,0 +1,16 @@
+package followMe.hub_server.stock.infrastructure.event;
+
+import org.springframework.context.ApplicationEventPublisher;
+
+public class Events {
+  private static ApplicationEventPublisher publisher;
+
+  static void setPublisher(ApplicationEventPublisher publisher) {
+    Events.publisher = publisher;
+  }
+
+  public static void publish(Object event) {
+    if (publisher == null) return;
+    publisher.publishEvent(event);
+  }
+}

--- a/src/main/java/followMe/hub_server/stock/infrastructure/persistence/HubStockHistoryRepositoryImpl.java
+++ b/src/main/java/followMe/hub_server/stock/infrastructure/persistence/HubStockHistoryRepositoryImpl.java
@@ -1,0 +1,9 @@
+package followMe.hub_server.stock.infrastructure.persistence;
+
+import followMe.hub_server.stock.domain.HubStockHistory;
+import followMe.hub_server.stock.domain.HubStockHistoryRepository;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HubStockHistoryRepositoryImpl
+    extends JpaRepository<HubStockHistory, UUID>, HubStockHistoryRepository {}

--- a/src/main/java/followMe/hub_server/stock/infrastructure/persistence/HubStockJpaRepository.java
+++ b/src/main/java/followMe/hub_server/stock/infrastructure/persistence/HubStockJpaRepository.java
@@ -1,0 +1,22 @@
+package followMe.hub_server.stock.infrastructure.persistence;
+
+import followMe.hub_server.stock.domain.HubStock;
+import java.util.Collection;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HubStockJpaRepository extends JpaRepository<HubStock, UUID> {
+  Collection<HubStock> findAllByProductIdIn(Collection<UUID> productIds);
+
+  Page<HubStock> findAll(Pageable pageable);
+
+  Page<HubStock> findAllByProductId(UUID productId, Pageable pageable);
+
+  Page<HubStock> findAllByHubId(UUID hubId, Pageable pageable);
+
+  Page<HubStock> findAllByVendor_Id(UUID vendorId, Pageable pageable);
+
+  Page<HubStock> findAllByProductIdIn(Collection<UUID> productIds, Pageable pageable);
+}

--- a/src/main/java/followMe/hub_server/stock/infrastructure/persistence/HubStockRepositoryImpl.java
+++ b/src/main/java/followMe/hub_server/stock/infrastructure/persistence/HubStockRepositoryImpl.java
@@ -1,0 +1,62 @@
+package followMe.hub_server.stock.infrastructure.persistence;
+
+import followMe.hub_server.stock.domain.HubStock;
+import followMe.hub_server.stock.domain.HubStockRepository;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class HubStockRepositoryImpl implements HubStockRepository {
+  private final HubStockJpaRepository jpaRepository;
+
+  @Override
+  public HubStock save(HubStock hubStock) {
+    return jpaRepository.save(hubStock);
+  }
+
+  @Override
+  public Optional<HubStock> findById(UUID productId) {
+    return jpaRepository.findById(productId);
+  }
+
+  @Override
+  public boolean existsById(UUID productId) {
+    return jpaRepository.existsById(productId);
+  }
+
+  @Override
+  public Collection<HubStock> findAllByProductIdIn(Collection<UUID> productIds) {
+    return jpaRepository.findAllByProductIdIn(productIds);
+  }
+
+  @Override
+  public Page<HubStock> findAllByProductId(UUID productId, Pageable pageable) {
+    return jpaRepository.findAllByProductId(productId, pageable);
+  }
+
+  @Override
+  public Page<HubStock> findAllByHubId(UUID hubId, Pageable pageable) {
+    return jpaRepository.findAllByHubId(hubId, pageable);
+  }
+
+  @Override
+  public Page<HubStock> findAllByVendor_Id(UUID vendorId, Pageable pageable) {
+    return jpaRepository.findAllByVendor_Id(vendorId, pageable);
+  }
+
+  @Override
+  public Page<HubStock> findAll(Pageable pageable) {
+    return jpaRepository.findAll(pageable);
+  }
+
+  @Override
+  public Page<HubStock> findAllByProductIdIn(Collection<UUID> productIds, Pageable pageable) {
+    return jpaRepository.findAllByProductIdIn(productIds, pageable);
+  }
+}


### PR DESCRIPTION
### 📌 관련 이슈
- close #15 

### 💡 작업 내용
- 재고 관리 서비스 로직 작성
  - 주문 요청과 주문 취소 로직 작성
- 재고 내역 저장 서비스 로직 작성
- 재고 내역 조회 서비스 로직 작성
- `QueryDSL` 도입 검토 중 이며, 현재는 JPA를 사용하여 조회
- 재고 관리 내역은 `Evnet` 기반으로 비동기로 `retry` 없이 저장


### 🔍 변경 이유

### 📝 리뷰 포인트 (선택)

### 🧠 기타 참고 사항