### PR TITLE
[Feat] 배송 경로 계산 라우팅 api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     implementation "com.followMe:common-lib:1.0.2"
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,12 @@ services:
       - "5433:5432"
     volumes:
       - hub_postgres_data:/var/lib/postgresql/data
+  redis:
+    image: redis:7
+    container_name: hub-redis
+    restart: always
+    ports:
+      - "6379:6379"
 
 volumes:
   hub_postgres_data:

--- a/src/main/java/followMe/hub_server/HubApplication.java
+++ b/src/main/java/followMe/hub_server/HubApplication.java
@@ -2,9 +2,13 @@ package followMe.hub_server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableCaching
 @EnableJpaAuditing
+@EnableFeignClients
 @SpringBootApplication
 public class HubApplication {
 

--- a/src/main/java/followMe/hub_server/common/config/CacheConfig.java
+++ b/src/main/java/followMe/hub_server/common/config/CacheConfig.java
@@ -1,0 +1,42 @@
+package followMe.hub_server.common.config;
+
+import java.time.Duration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        GenericJackson2JsonRedisSerializer serializer =
+                new GenericJackson2JsonRedisSerializer();
+
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .disableCachingNullValues()
+                .entryTtl(Duration.ofMinutes(30))
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(serializer)
+                );
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(defaultConfig)
+                .withCacheConfiguration(
+                        "hubRoutePath",
+                        defaultConfig.entryTtl(Duration.ofHours(1))
+                )
+                .withCacheConfiguration(
+                        "vendorInfo",
+                        defaultConfig.entryTtl(Duration.ofMinutes(10))
+                )
+                .build();
+    }
+}

--- a/src/main/java/followMe/hub_server/common/config/CacheConfig.java
+++ b/src/main/java/followMe/hub_server/common/config/CacheConfig.java
@@ -15,28 +15,21 @@ import org.springframework.data.redis.serializer.RedisSerializationContext;
 @EnableCaching
 public class CacheConfig {
 
-    @Bean
-    public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
-        GenericJackson2JsonRedisSerializer serializer =
-                new GenericJackson2JsonRedisSerializer();
+  @Bean
+  public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+    GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer();
 
-        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
-                .disableCachingNullValues()
-                .entryTtl(Duration.ofMinutes(30))
-                .serializeValuesWith(
-                        RedisSerializationContext.SerializationPair.fromSerializer(serializer)
-                );
+    RedisCacheConfiguration defaultConfig =
+        RedisCacheConfiguration.defaultCacheConfig()
+            .disableCachingNullValues()
+            .entryTtl(Duration.ofMinutes(30))
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(serializer));
 
-        return RedisCacheManager.builder(connectionFactory)
-                .cacheDefaults(defaultConfig)
-                .withCacheConfiguration(
-                        "hubRoutePath",
-                        defaultConfig.entryTtl(Duration.ofHours(1))
-                )
-                .withCacheConfiguration(
-                        "vendorInfo",
-                        defaultConfig.entryTtl(Duration.ofMinutes(10))
-                )
-                .build();
-    }
+    return RedisCacheManager.builder(connectionFactory)
+        .cacheDefaults(defaultConfig)
+        .withCacheConfiguration("hubRoutePath", defaultConfig.entryTtl(Duration.ofHours(1)))
+        .withCacheConfiguration("vendorInfo", defaultConfig.entryTtl(Duration.ofMinutes(10)))
+        .build();
+  }
 }

--- a/src/main/java/followMe/hub_server/hub/application/dto/enums/NodeType.java
+++ b/src/main/java/followMe/hub_server/hub/application/dto/enums/NodeType.java
@@ -1,0 +1,6 @@
+package followMe.hub_server.hub.application.dto.enums;
+
+public enum NodeType {
+    HUB,
+    VENDOR
+}

--- a/src/main/java/followMe/hub_server/hub/application/dto/enums/NodeType.java
+++ b/src/main/java/followMe/hub_server/hub/application/dto/enums/NodeType.java
@@ -1,6 +1,6 @@
 package followMe.hub_server.hub.application.dto.enums;
 
 public enum NodeType {
-    HUB,
-    VENDOR
+  HUB,
+  VENDOR
 }

--- a/src/main/java/followMe/hub_server/hub/application/dto/result/HubPathResult.java
+++ b/src/main/java/followMe/hub_server/hub/application/dto/result/HubPathResult.java
@@ -2,10 +2,5 @@ package followMe.hub_server.hub.application.dto.result;
 
 import java.util.List;
 
-/**
- * 허브 경로 캐시용
- * 응답에는 사용되지 않음
- */
-public record HubPathResult(
-        List<RouteNodeResult> hubNodes
-) {}
+/** 허브 경로 캐시용 응답에는 사용되지 않음 */
+public record HubPathResult(List<RouteNodeResult> hubNodes) {}

--- a/src/main/java/followMe/hub_server/hub/application/dto/result/HubPathResult.java
+++ b/src/main/java/followMe/hub_server/hub/application/dto/result/HubPathResult.java
@@ -1,0 +1,11 @@
+package followMe.hub_server.hub.application.dto.result;
+
+import java.util.List;
+
+/**
+ * 허브 경로 캐시용
+ * 응답에는 사용되지 않음
+ */
+public record HubPathResult(
+        List<RouteNodeResult> hubNodes
+) {}

--- a/src/main/java/followMe/hub_server/hub/application/dto/result/HubRouteResult.java
+++ b/src/main/java/followMe/hub_server/hub/application/dto/result/HubRouteResult.java
@@ -2,7 +2,4 @@ package followMe.hub_server.hub.application.dto.result;
 
 import java.util.List;
 
-public record HubRouteResult(
-        List<RouteNodeResult> nodes
-) {
-}
+public record HubRouteResult(List<RouteNodeResult> nodes) {}

--- a/src/main/java/followMe/hub_server/hub/application/dto/result/HubRouteResult.java
+++ b/src/main/java/followMe/hub_server/hub/application/dto/result/HubRouteResult.java
@@ -1,0 +1,8 @@
+package followMe.hub_server.hub.application.dto.result;
+
+import java.util.List;
+
+public record HubRouteResult(
+        List<RouteNodeResult> nodes
+) {
+}

--- a/src/main/java/followMe/hub_server/hub/application/dto/result/RouteNodeResult.java
+++ b/src/main/java/followMe/hub_server/hub/application/dto/result/RouteNodeResult.java
@@ -1,0 +1,12 @@
+package followMe.hub_server.hub.application.dto.result;
+
+import followMe.hub_server.hub.application.dto.enums.NodeType;
+
+import java.util.UUID;
+
+public record RouteNodeResult(
+        UUID id,
+        NodeType type,
+        String name,
+        int sequence
+) {}

--- a/src/main/java/followMe/hub_server/hub/application/dto/result/RouteNodeResult.java
+++ b/src/main/java/followMe/hub_server/hub/application/dto/result/RouteNodeResult.java
@@ -1,12 +1,6 @@
 package followMe.hub_server.hub.application.dto.result;
 
 import followMe.hub_server.hub.application.dto.enums.NodeType;
-
 import java.util.UUID;
 
-public record RouteNodeResult(
-        UUID id,
-        NodeType type,
-        String name,
-        int sequence
-) {}
+public record RouteNodeResult(UUID id, NodeType type, String name, int sequence) {}

--- a/src/main/java/followMe/hub_server/hub/application/service/HubRoutePathQueryService.java
+++ b/src/main/java/followMe/hub_server/hub/application/service/HubRoutePathQueryService.java
@@ -29,6 +29,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class HubRoutePathQueryService {
 
+  // 한 번에 직접 이동 가능한 최대 거리 기준
+  // 이 거리보다 짧은 경로만 그래프에 포함시켜서 경로 탐색에 사용
   private static final BigDecimal MAX_SEGMENT_DISTANCE = new BigDecimal("200");
 
   private final HubRepository hubRepository;
@@ -54,22 +56,33 @@ public class HubRoutePathQueryService {
   }
 
   private List<Hub> findShortestPath(Hub sourceHub, Hub destinationHub) {
+    // 출발 허브와 도착 허브가 같으면 이동이 필요 없으므로 자기 자신만 반환
     if (sourceHub.getHubId().equals(destinationHub.getHubId())) {
       return List.of(sourceHub);
     }
 
-    // 허브간 이동 정보 모두 가져오기
+    // DB에 저장된 허브 간 이동 정보 전체 조회
+    // 이후 이 데이터를 기반으로 그래프를 구성
     List<HubRoute> allRoutes = hubRouteRepository.findAll();
 
-    // 각 허브별로 갈 수 있는 허브 경로 정보 등록
+    // 그래프 구조
+    // key: 출발 허브 ID
+    // value: 해당 허브에서 이동 가능한 HubRoute 목록
     Map<UUID, List<HubRoute>> graph = new HashMap<>();
+
+    // 전체 경로 정보를 순회하면서 그래프를 구성
     for (HubRoute route : allRoutes) {
       UUID originHubId = route.getOriginHub().getHubId();
       UUID destinationHubId = route.getDestinationHub().getHubId();
 
+      // 직접 이동 가능한 최대 거리보다 짧은 경로만 그래프에 포함
       if (route.getDistance().compareTo(MAX_SEGMENT_DISTANCE) < 0) {
+        // 정방향 경로 추가
+        // originHubId -> destinationHubId
         graph.computeIfAbsent(originHubId, key -> new ArrayList<>()).add(route);
 
+        // 역방향 경로도 추가
+        // destinationHubId -> originHubId 형태의 HubRoute를 새로 만들어 넣음
         graph
             .computeIfAbsent(destinationHubId, key -> new ArrayList<>())
             .add(
@@ -81,48 +94,80 @@ public class HubRoutePathQueryService {
       }
     }
 
+    /*---다익스트라 알고리즘용 자료구조---*/
+
+    // 출발지로부터 각 허브까지의 현재까지 알려진 최단 거리 저장
     Map<UUID, BigDecimal> distances = new HashMap<>();
+
+    // 최단 경로를 복원하기 위해 특정 허브에 오기 직전의 허브 ID를 저장
     Map<UUID, UUID> previous = new HashMap<>();
+
+    // 가장 짧은 거리 상태를 우선 꺼내기 위한 우선순위 큐
+    // distance 기준 오름차순 정렬
     PriorityQueue<RouteState> pq = new PriorityQueue<>(Comparator.comparing(RouteState::distance));
 
+    // 시작 허브까지의 거리는 0
     distances.put(sourceHub.getHubId(), BigDecimal.ZERO);
+
+    // 우선순위 큐에 시작 상태 삽입
     pq.offer(new RouteState(sourceHub.getHubId(), BigDecimal.ZERO));
 
+    /*---다익스트라 알고리즘 수행---*/
     while (!pq.isEmpty()) {
+      // 현재까지 가장 짧은 거리 후보를 꺼냄
       RouteState current = pq.poll();
 
+      // 현재 허브에 대해 이미 더 짧은 경로가 저장되어 있다면 지금 꺼낸 정보는 오래된 정보이므로 무시
       BigDecimal bestDistance = distances.get(current.hubId());
       if (bestDistance != null && current.distance().compareTo(bestDistance) > 0) {
         continue;
       }
 
+      // 도착 허브에 도달했다면 종료 (우선순위 큐 특성상 이 시점의 거리가 최단 거리)
       if (current.hubId().equals(destinationHub.getHubId())) {
         break;
       }
 
+      // 현재 허브에서 갈 수 있는 다음 허브들을 확인
       for (HubRoute nextRoute : graph.getOrDefault(current.hubId(), List.of())) {
         UUID nextHubId = nextRoute.getDestinationHub().getHubId();
+
+        // 현재까지 거리 + 다음 간선 거리
         BigDecimal nextDistance = current.distance().add(nextRoute.getDistance());
 
+        // 기존에 저장된 다음 허브까지의 거리 조회
         BigDecimal savedDistance = distances.get(nextHubId);
+
+        // 아직 방문하지 않았거나 이번에 계산한 거리가 더 짧으면 최단 거리 갱신
         if (savedDistance == null || nextDistance.compareTo(savedDistance) < 0) {
           distances.put(nextHubId, nextDistance);
+
+          // nextHubId에 도달하기 직전 허브를 기록
           previous.put(nextHubId, current.hubId());
+
+          // 갱신된 거리 정보로 우선순위 큐에 추가
           pq.offer(new RouteState(nextHubId, nextDistance));
         }
       }
     }
 
+    // 도착 허브까지의 최단 거리가 끝내 계산되지 않았다면 갈 수 있는 경로가 없다는 의미
     if (!distances.containsKey(destinationHub.getHubId())) {
       throw new HubRouteNotFoundException();
     }
 
+    // previous 맵을 이용해 도착지부터 출발지까지 역추적하여 실제 경로 복원
     LinkedList<Hub> path = new LinkedList<>();
     UUID cursor = destinationHub.getHubId();
 
     while (cursor != null) {
+      // 허브 ID로 실제 Hub 엔티티 조회
       Hub hub = hubRepository.findById(cursor).orElseThrow(HubNotFoundException::new);
+
+      // 역추적 중이므로 앞에 삽입해서 출발지 -> 도착지 순서로 맞춤
       path.addFirst(hub);
+
+      // 직전 허브로 이동
       cursor = previous.get(cursor);
     }
 

--- a/src/main/java/followMe/hub_server/hub/application/service/HubRoutePathQueryService.java
+++ b/src/main/java/followMe/hub_server/hub/application/service/HubRoutePathQueryService.java
@@ -1,0 +1,140 @@
+package followMe.hub_server.hub.application.service;
+
+import followMe.hub_server.hub.application.dto.enums.NodeType;
+import followMe.hub_server.hub.application.dto.result.HubPathResult;
+import followMe.hub_server.hub.application.dto.result.RouteNodeResult;
+import followMe.hub_server.hub.domain.entity.Hub;
+import followMe.hub_server.hub.domain.entity.HubRoute;
+import followMe.hub_server.hub.domain.repository.HubRepository;
+import followMe.hub_server.hub.domain.repository.HubRouteRepository;
+import followMe.hub_server.hub.exception.detail.HubNotFoundException;
+import followMe.hub_server.hub.exception.detail.HubRouteNotFoundException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HubRoutePathQueryService {
+
+    private static final BigDecimal MAX_SEGMENT_DISTANCE = new BigDecimal("200");
+
+    private final HubRepository hubRepository;
+    private final HubRouteRepository hubRouteRepository;
+
+    @Cacheable(
+            value = "hubRoutePath",
+            key = "#sourceHubId.toString() + ':' + #destinationHubId.toString()")
+    public HubPathResult getHubPath(UUID sourceHubId, UUID destinationHubId) {
+        Hub sourceHub = hubRepository.findById(sourceHubId).orElseThrow(HubNotFoundException::new);
+        Hub destinationHub = hubRepository.findById(destinationHubId).orElseThrow(HubNotFoundException::new);
+
+        List<Hub> hubs = findShortestPath(sourceHub, destinationHub);
+
+        List<RouteNodeResult> hubNodes = new ArrayList<>();
+        for (int i = 0; i < hubs.size(); i++) {
+            Hub hub = hubs.get(i);
+            hubNodes.add(
+                    new RouteNodeResult(
+                            hub.getHubId(),
+                            NodeType.HUB,
+                            hub.getHubName(),
+                            i + 1));
+        }
+
+        return new HubPathResult(hubNodes);
+    }
+
+    private List<Hub> findShortestPath(Hub sourceHub, Hub destinationHub) {
+        if (sourceHub.getHubId().equals(destinationHub.getHubId())) {
+            return List.of(sourceHub);
+        }
+
+        // 허브간 이동 정보 모두 가져오기
+        List<HubRoute> allRoutes = hubRouteRepository.findAll();
+
+        // 각 허브별로 갈 수 있는 허브 경로 정보 등록
+        Map<UUID, List<HubRoute>> graph = new HashMap<>();
+        for (HubRoute route : allRoutes) {
+            UUID originHubId = route.getOriginHub().getHubId();
+            UUID destinationHubId = route.getDestinationHub().getHubId();
+
+            if (route.getDistance().compareTo(MAX_SEGMENT_DISTANCE) < 0) {
+                graph.computeIfAbsent(originHubId, key -> new ArrayList<>()).add(route);
+
+                graph.computeIfAbsent(destinationHubId, key -> new ArrayList<>())
+                        .add(new HubRoute(
+                                route.getDestinationHub(),
+                                route.getOriginHub(),
+                                route.getDuration(),
+                                route.getDistance()
+                        ));
+            }
+        }
+
+        Map<UUID, BigDecimal> distances = new HashMap<>();
+        Map<UUID, UUID> previous = new HashMap<>();
+        PriorityQueue<RouteState> pq =
+                new PriorityQueue<>(Comparator.comparing(RouteState::distance));
+
+        distances.put(sourceHub.getHubId(), BigDecimal.ZERO);
+        pq.offer(new RouteState(sourceHub.getHubId(), BigDecimal.ZERO));
+
+        while (!pq.isEmpty()) {
+            RouteState current = pq.poll();
+
+            BigDecimal bestDistance = distances.get(current.hubId());
+            if (bestDistance != null && current.distance().compareTo(bestDistance) > 0) {
+                continue;
+            }
+
+            if (current.hubId().equals(destinationHub.getHubId())) {
+                break;
+            }
+
+            for (HubRoute nextRoute : graph.getOrDefault(current.hubId(), List.of())) {
+                UUID nextHubId = nextRoute.getDestinationHub().getHubId();
+                BigDecimal nextDistance = current.distance().add(nextRoute.getDistance());
+
+                BigDecimal savedDistance = distances.get(nextHubId);
+                if (savedDistance == null || nextDistance.compareTo(savedDistance) < 0) {
+                    distances.put(nextHubId, nextDistance);
+                    previous.put(nextHubId, current.hubId());
+                    pq.offer(new RouteState(nextHubId, nextDistance));
+                }
+            }
+        }
+
+        if (!distances.containsKey(destinationHub.getHubId())) {
+            throw new HubRouteNotFoundException();
+        }
+
+        LinkedList<Hub> path = new LinkedList<>();
+        UUID cursor = destinationHub.getHubId();
+
+        while (cursor != null) {
+            Hub hub = hubRepository.findById(cursor).orElseThrow(HubNotFoundException::new);
+            path.addFirst(hub);
+            cursor = previous.get(cursor);
+        }
+
+        return path;
+    }
+
+    @CacheEvict(value = "hubRoutePath", allEntries = true)
+    public void evictAllPathCache() {}
+
+    private record RouteState(UUID hubId, BigDecimal distance) {}
+}

--- a/src/main/java/followMe/hub_server/hub/application/service/HubRoutePathQueryService.java
+++ b/src/main/java/followMe/hub_server/hub/application/service/HubRoutePathQueryService.java
@@ -29,112 +29,108 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class HubRoutePathQueryService {
 
-    private static final BigDecimal MAX_SEGMENT_DISTANCE = new BigDecimal("200");
+  private static final BigDecimal MAX_SEGMENT_DISTANCE = new BigDecimal("200");
 
-    private final HubRepository hubRepository;
-    private final HubRouteRepository hubRouteRepository;
+  private final HubRepository hubRepository;
+  private final HubRouteRepository hubRouteRepository;
 
-    @Cacheable(
-            value = "hubRoutePath",
-            key = "#sourceHubId.toString() + ':' + #destinationHubId.toString()")
-    public HubPathResult getHubPath(UUID sourceHubId, UUID destinationHubId) {
-        Hub sourceHub = hubRepository.findById(sourceHubId).orElseThrow(HubNotFoundException::new);
-        Hub destinationHub = hubRepository.findById(destinationHubId).orElseThrow(HubNotFoundException::new);
+  @Cacheable(
+      value = "hubRoutePath",
+      key = "#sourceHubId.toString() + ':' + #destinationHubId.toString()")
+  public HubPathResult getHubPath(UUID sourceHubId, UUID destinationHubId) {
+    Hub sourceHub = hubRepository.findById(sourceHubId).orElseThrow(HubNotFoundException::new);
+    Hub destinationHub =
+        hubRepository.findById(destinationHubId).orElseThrow(HubNotFoundException::new);
 
-        List<Hub> hubs = findShortestPath(sourceHub, destinationHub);
+    List<Hub> hubs = findShortestPath(sourceHub, destinationHub);
 
-        List<RouteNodeResult> hubNodes = new ArrayList<>();
-        for (int i = 0; i < hubs.size(); i++) {
-            Hub hub = hubs.get(i);
-            hubNodes.add(
-                    new RouteNodeResult(
-                            hub.getHubId(),
-                            NodeType.HUB,
-                            hub.getHubName(),
-                            i + 1));
-        }
-
-        return new HubPathResult(hubNodes);
+    List<RouteNodeResult> hubNodes = new ArrayList<>();
+    for (int i = 0; i < hubs.size(); i++) {
+      Hub hub = hubs.get(i);
+      hubNodes.add(new RouteNodeResult(hub.getHubId(), NodeType.HUB, hub.getHubName(), i + 1));
     }
 
-    private List<Hub> findShortestPath(Hub sourceHub, Hub destinationHub) {
-        if (sourceHub.getHubId().equals(destinationHub.getHubId())) {
-            return List.of(sourceHub);
-        }
+    return new HubPathResult(hubNodes);
+  }
 
-        // 허브간 이동 정보 모두 가져오기
-        List<HubRoute> allRoutes = hubRouteRepository.findAll();
-
-        // 각 허브별로 갈 수 있는 허브 경로 정보 등록
-        Map<UUID, List<HubRoute>> graph = new HashMap<>();
-        for (HubRoute route : allRoutes) {
-            UUID originHubId = route.getOriginHub().getHubId();
-            UUID destinationHubId = route.getDestinationHub().getHubId();
-
-            if (route.getDistance().compareTo(MAX_SEGMENT_DISTANCE) < 0) {
-                graph.computeIfAbsent(originHubId, key -> new ArrayList<>()).add(route);
-
-                graph.computeIfAbsent(destinationHubId, key -> new ArrayList<>())
-                        .add(new HubRoute(
-                                route.getDestinationHub(),
-                                route.getOriginHub(),
-                                route.getDuration(),
-                                route.getDistance()
-                        ));
-            }
-        }
-
-        Map<UUID, BigDecimal> distances = new HashMap<>();
-        Map<UUID, UUID> previous = new HashMap<>();
-        PriorityQueue<RouteState> pq =
-                new PriorityQueue<>(Comparator.comparing(RouteState::distance));
-
-        distances.put(sourceHub.getHubId(), BigDecimal.ZERO);
-        pq.offer(new RouteState(sourceHub.getHubId(), BigDecimal.ZERO));
-
-        while (!pq.isEmpty()) {
-            RouteState current = pq.poll();
-
-            BigDecimal bestDistance = distances.get(current.hubId());
-            if (bestDistance != null && current.distance().compareTo(bestDistance) > 0) {
-                continue;
-            }
-
-            if (current.hubId().equals(destinationHub.getHubId())) {
-                break;
-            }
-
-            for (HubRoute nextRoute : graph.getOrDefault(current.hubId(), List.of())) {
-                UUID nextHubId = nextRoute.getDestinationHub().getHubId();
-                BigDecimal nextDistance = current.distance().add(nextRoute.getDistance());
-
-                BigDecimal savedDistance = distances.get(nextHubId);
-                if (savedDistance == null || nextDistance.compareTo(savedDistance) < 0) {
-                    distances.put(nextHubId, nextDistance);
-                    previous.put(nextHubId, current.hubId());
-                    pq.offer(new RouteState(nextHubId, nextDistance));
-                }
-            }
-        }
-
-        if (!distances.containsKey(destinationHub.getHubId())) {
-            throw new HubRouteNotFoundException();
-        }
-
-        LinkedList<Hub> path = new LinkedList<>();
-        UUID cursor = destinationHub.getHubId();
-
-        while (cursor != null) {
-            Hub hub = hubRepository.findById(cursor).orElseThrow(HubNotFoundException::new);
-            path.addFirst(hub);
-            cursor = previous.get(cursor);
-        }
-
-        return path;
+  private List<Hub> findShortestPath(Hub sourceHub, Hub destinationHub) {
+    if (sourceHub.getHubId().equals(destinationHub.getHubId())) {
+      return List.of(sourceHub);
     }
 
-    @CacheEvict(value = "hubRoutePath", allEntries = true)
-    public void evictAllPathCache() {}
+    // 허브간 이동 정보 모두 가져오기
+    List<HubRoute> allRoutes = hubRouteRepository.findAll();
 
-    private record RouteState(UUID hubId, BigDecimal distance) {}
+    // 각 허브별로 갈 수 있는 허브 경로 정보 등록
+    Map<UUID, List<HubRoute>> graph = new HashMap<>();
+    for (HubRoute route : allRoutes) {
+      UUID originHubId = route.getOriginHub().getHubId();
+      UUID destinationHubId = route.getDestinationHub().getHubId();
+
+      if (route.getDistance().compareTo(MAX_SEGMENT_DISTANCE) < 0) {
+        graph.computeIfAbsent(originHubId, key -> new ArrayList<>()).add(route);
+
+        graph
+            .computeIfAbsent(destinationHubId, key -> new ArrayList<>())
+            .add(
+                new HubRoute(
+                    route.getDestinationHub(),
+                    route.getOriginHub(),
+                    route.getDuration(),
+                    route.getDistance()));
+      }
+    }
+
+    Map<UUID, BigDecimal> distances = new HashMap<>();
+    Map<UUID, UUID> previous = new HashMap<>();
+    PriorityQueue<RouteState> pq = new PriorityQueue<>(Comparator.comparing(RouteState::distance));
+
+    distances.put(sourceHub.getHubId(), BigDecimal.ZERO);
+    pq.offer(new RouteState(sourceHub.getHubId(), BigDecimal.ZERO));
+
+    while (!pq.isEmpty()) {
+      RouteState current = pq.poll();
+
+      BigDecimal bestDistance = distances.get(current.hubId());
+      if (bestDistance != null && current.distance().compareTo(bestDistance) > 0) {
+        continue;
+      }
+
+      if (current.hubId().equals(destinationHub.getHubId())) {
+        break;
+      }
+
+      for (HubRoute nextRoute : graph.getOrDefault(current.hubId(), List.of())) {
+        UUID nextHubId = nextRoute.getDestinationHub().getHubId();
+        BigDecimal nextDistance = current.distance().add(nextRoute.getDistance());
+
+        BigDecimal savedDistance = distances.get(nextHubId);
+        if (savedDistance == null || nextDistance.compareTo(savedDistance) < 0) {
+          distances.put(nextHubId, nextDistance);
+          previous.put(nextHubId, current.hubId());
+          pq.offer(new RouteState(nextHubId, nextDistance));
+        }
+      }
+    }
+
+    if (!distances.containsKey(destinationHub.getHubId())) {
+      throw new HubRouteNotFoundException();
+    }
+
+    LinkedList<Hub> path = new LinkedList<>();
+    UUID cursor = destinationHub.getHubId();
+
+    while (cursor != null) {
+      Hub hub = hubRepository.findById(cursor).orElseThrow(HubNotFoundException::new);
+      path.addFirst(hub);
+      cursor = previous.get(cursor);
+    }
+
+    return path;
+  }
+
+  @CacheEvict(value = "hubRoutePath", allEntries = true)
+  public void evictAllPathCache() {}
+
+  private record RouteState(UUID hubId, BigDecimal distance) {}
 }

--- a/src/main/java/followMe/hub_server/hub/application/service/HubRouteService.java
+++ b/src/main/java/followMe/hub_server/hub/application/service/HubRouteService.java
@@ -1,0 +1,10 @@
+package followMe.hub_server.hub.application.service;
+
+import followMe.hub_server.hub.application.dto.result.HubRouteResult;
+
+import java.util.UUID;
+
+public interface HubRouteService {
+
+    HubRouteResult getRoute(UUID sourceHubId, UUID vendorId);
+}

--- a/src/main/java/followMe/hub_server/hub/application/service/HubRouteService.java
+++ b/src/main/java/followMe/hub_server/hub/application/service/HubRouteService.java
@@ -1,10 +1,9 @@
 package followMe.hub_server.hub.application.service;
 
 import followMe.hub_server.hub.application.dto.result.HubRouteResult;
-
 import java.util.UUID;
 
 public interface HubRouteService {
 
-    HubRouteResult getRoute(UUID sourceHubId, UUID vendorId);
+  HubRouteResult getRoute(UUID sourceHubId, UUID vendorId);
 }

--- a/src/main/java/followMe/hub_server/hub/application/service/HubRouteServiceImpl.java
+++ b/src/main/java/followMe/hub_server/hub/application/service/HubRouteServiceImpl.java
@@ -8,48 +8,42 @@ import followMe.hub_server.hub.exception.detail.InvalidVendorResponseException;
 import followMe.hub_server.hub.exception.detail.VendorNotFoundException;
 import followMe.hub_server.hub.infrastructure.client.VendorClient;
 import followMe.hub_server.hub.infrastructure.client.dto.VendorResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class HubRouteServiceImpl implements HubRouteService{
+public class HubRouteServiceImpl implements HubRouteService {
 
-    private final VendorClient vendorClient;
-    private final HubRoutePathQueryService hubRoutePathQueryService;
+  private final VendorClient vendorClient;
+  private final HubRoutePathQueryService hubRoutePathQueryService;
 
-    @Override
-    public HubRouteResult getRoute(UUID sourceHubId, UUID vendorId) {
-        VendorResponse vendorResponse = vendorClient.getVendor(vendorId);
+  @Override
+  public HubRouteResult getRoute(UUID sourceHubId, UUID vendorId) {
+    VendorResponse vendorResponse = vendorClient.getVendor(vendorId);
 
-        if (vendorResponse == null) {
-            throw new VendorNotFoundException();
-        }
-        if (vendorResponse.hubId() == null) {
-            throw new InvalidVendorResponseException();
-        }
-
-        // 허브 간 경로 계산
-        HubPathResult hubPathResult =
-                hubRoutePathQueryService.getHubPath(sourceHubId, vendorResponse.hubId());
-
-        List<RouteNodeResult> nodes = new ArrayList<>(hubPathResult.hubNodes());
-
-        nodes.add(
-                new RouteNodeResult(
-                        vendorResponse.vendorId(),
-                        NodeType.VENDOR,
-                        vendorResponse.name(),
-                        nodes.size() + 1
-                )
-        );
-
-        return new HubRouteResult(nodes);
+    if (vendorResponse == null) {
+      throw new VendorNotFoundException();
     }
+    if (vendorResponse.hubId() == null) {
+      throw new InvalidVendorResponseException();
+    }
+
+    // 허브 간 경로 계산
+    HubPathResult hubPathResult =
+        hubRoutePathQueryService.getHubPath(sourceHubId, vendorResponse.hubId());
+
+    List<RouteNodeResult> nodes = new ArrayList<>(hubPathResult.hubNodes());
+
+    nodes.add(
+        new RouteNodeResult(
+            vendorResponse.vendorId(), NodeType.VENDOR, vendorResponse.name(), nodes.size() + 1));
+
+    return new HubRouteResult(nodes);
+  }
 }

--- a/src/main/java/followMe/hub_server/hub/application/service/HubRouteServiceImpl.java
+++ b/src/main/java/followMe/hub_server/hub/application/service/HubRouteServiceImpl.java
@@ -1,0 +1,55 @@
+package followMe.hub_server.hub.application.service;
+
+import followMe.hub_server.hub.application.dto.enums.NodeType;
+import followMe.hub_server.hub.application.dto.result.HubPathResult;
+import followMe.hub_server.hub.application.dto.result.HubRouteResult;
+import followMe.hub_server.hub.application.dto.result.RouteNodeResult;
+import followMe.hub_server.hub.exception.detail.InvalidVendorResponseException;
+import followMe.hub_server.hub.exception.detail.VendorNotFoundException;
+import followMe.hub_server.hub.infrastructure.client.VendorClient;
+import followMe.hub_server.hub.infrastructure.client.dto.VendorResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HubRouteServiceImpl implements HubRouteService{
+
+    private final VendorClient vendorClient;
+    private final HubRoutePathQueryService hubRoutePathQueryService;
+
+    @Override
+    public HubRouteResult getRoute(UUID sourceHubId, UUID vendorId) {
+        VendorResponse vendorResponse = vendorClient.getVendor(vendorId);
+
+        if (vendorResponse == null) {
+            throw new VendorNotFoundException();
+        }
+        if (vendorResponse.hubId() == null) {
+            throw new InvalidVendorResponseException();
+        }
+
+        // 허브 간 경로 계산
+        HubPathResult hubPathResult =
+                hubRoutePathQueryService.getHubPath(sourceHubId, vendorResponse.hubId());
+
+        List<RouteNodeResult> nodes = new ArrayList<>(hubPathResult.hubNodes());
+
+        nodes.add(
+                new RouteNodeResult(
+                        vendorResponse.vendorId(),
+                        NodeType.VENDOR,
+                        vendorResponse.name(),
+                        nodes.size() + 1
+                )
+        );
+
+        return new HubRouteResult(nodes);
+    }
+}

--- a/src/main/java/followMe/hub_server/hub/application/service/UserContext.java
+++ b/src/main/java/followMe/hub_server/hub/application/service/UserContext.java
@@ -2,4 +2,10 @@ package followMe.hub_server.hub.application.service;
 
 import java.util.UUID;
 
-public record UserContext(UUID userId, UserRole role, UUID hubId, UUID vendorId) {}
+public record UserContext(
+        UUID userId,
+        UserRole role,
+        UUID hubId,
+        UUID vendorId,
+        String userName
+) {}

--- a/src/main/java/followMe/hub_server/hub/application/service/UserContext.java
+++ b/src/main/java/followMe/hub_server/hub/application/service/UserContext.java
@@ -2,10 +2,4 @@ package followMe.hub_server.hub.application.service;
 
 import java.util.UUID;
 
-public record UserContext(
-        UUID userId,
-        UserRole role,
-        UUID hubId,
-        UUID vendorId,
-        String userName
-) {}
+public record UserContext(UUID userId, UserRole role, UUID hubId, UUID vendorId, String userName) {}

--- a/src/main/java/followMe/hub_server/hub/exception/HubErrorCode.java
+++ b/src/main/java/followMe/hub_server/hub/exception/HubErrorCode.java
@@ -24,8 +24,8 @@ public enum HubErrorCode implements ErrorCode {
   ORIGIN_HUB_REQUIRED(HttpStatus.BAD_REQUEST, "HUB_014", "출발 허브는 필수입니다."),
   DESTINATION_HUB_REQUIRED(HttpStatus.BAD_REQUEST, "HUB_015", "도착 허브는 필수입니다."),
   INVALID_AUTH(HttpStatus.UNAUTHORIZED, "HUB_016", "권한이 없습니다."),
-    VENDOR_NOT_FOUND(HttpStatus.NOT_FOUND, "HUB_017", "업체 정보를 찾을 수 없습니다."),
-    INVALID_VENDOR_RESPONSE(HttpStatus.BAD_REQUEST, "HUB_018", "업체에 소속 허브 정보가 없습니다.");
+  VENDOR_NOT_FOUND(HttpStatus.NOT_FOUND, "HUB_017", "업체 정보를 찾을 수 없습니다."),
+  INVALID_VENDOR_RESPONSE(HttpStatus.BAD_REQUEST, "HUB_018", "업체에 소속 허브 정보가 없습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/followMe/hub_server/hub/exception/HubErrorCode.java
+++ b/src/main/java/followMe/hub_server/hub/exception/HubErrorCode.java
@@ -23,7 +23,9 @@ public enum HubErrorCode implements ErrorCode {
   INVALID_DELETED_BY(HttpStatus.BAD_REQUEST, "HUB_013", "삭제자 정보가 올바르지 않습니다."),
   ORIGIN_HUB_REQUIRED(HttpStatus.BAD_REQUEST, "HUB_014", "출발 허브는 필수입니다."),
   DESTINATION_HUB_REQUIRED(HttpStatus.BAD_REQUEST, "HUB_015", "도착 허브는 필수입니다."),
-  INVALID_AUTH(HttpStatus.UNAUTHORIZED, "HUB_016", "권한이 없습니다.");
+  INVALID_AUTH(HttpStatus.UNAUTHORIZED, "HUB_016", "권한이 없습니다."),
+    VENDOR_NOT_FOUND(HttpStatus.NOT_FOUND, "HUB_017", "업체 정보를 찾을 수 없습니다."),
+    INVALID_VENDOR_RESPONSE(HttpStatus.BAD_REQUEST, "HUB_018", "업체에 소속 허브 정보가 없습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/followMe/hub_server/hub/exception/detail/InvalidVendorResponseException.java
+++ b/src/main/java/followMe/hub_server/hub/exception/detail/InvalidVendorResponseException.java
@@ -1,0 +1,11 @@
+package followMe.hub_server.hub.exception.detail;
+
+import followMe.hub_server.hub.exception.HubErrorCode;
+import followMe.hub_server.hub.exception.HubException;
+
+public class InvalidVendorResponseException extends HubException {
+
+    public InvalidVendorResponseException() {
+        super(HubErrorCode.INVALID_VENDOR_RESPONSE);
+    }
+}

--- a/src/main/java/followMe/hub_server/hub/exception/detail/InvalidVendorResponseException.java
+++ b/src/main/java/followMe/hub_server/hub/exception/detail/InvalidVendorResponseException.java
@@ -5,7 +5,7 @@ import followMe.hub_server.hub.exception.HubException;
 
 public class InvalidVendorResponseException extends HubException {
 
-    public InvalidVendorResponseException() {
-        super(HubErrorCode.INVALID_VENDOR_RESPONSE);
-    }
+  public InvalidVendorResponseException() {
+    super(HubErrorCode.INVALID_VENDOR_RESPONSE);
+  }
 }

--- a/src/main/java/followMe/hub_server/hub/exception/detail/VendorNotFoundException.java
+++ b/src/main/java/followMe/hub_server/hub/exception/detail/VendorNotFoundException.java
@@ -1,0 +1,10 @@
+package followMe.hub_server.hub.exception.detail;
+
+import followMe.hub_server.hub.exception.HubErrorCode;
+import followMe.hub_server.hub.exception.HubException;
+
+public class VendorNotFoundException extends HubException {
+    public VendorNotFoundException() {
+        super(HubErrorCode.HUB_NOT_FOUND);
+    }
+}

--- a/src/main/java/followMe/hub_server/hub/exception/detail/VendorNotFoundException.java
+++ b/src/main/java/followMe/hub_server/hub/exception/detail/VendorNotFoundException.java
@@ -4,7 +4,7 @@ import followMe.hub_server.hub.exception.HubErrorCode;
 import followMe.hub_server.hub.exception.HubException;
 
 public class VendorNotFoundException extends HubException {
-    public VendorNotFoundException() {
-        super(HubErrorCode.HUB_NOT_FOUND);
-    }
+  public VendorNotFoundException() {
+    super(HubErrorCode.HUB_NOT_FOUND);
+  }
 }

--- a/src/main/java/followMe/hub_server/hub/infrastructure/client/VendorClient.java
+++ b/src/main/java/followMe/hub_server/hub/infrastructure/client/VendorClient.java
@@ -2,18 +2,14 @@ package followMe.hub_server.hub.infrastructure.client;
 
 import followMe.hub_server.hub.infrastructure.client.config.VendorClientFeignConfig;
 import followMe.hub_server.hub.infrastructure.client.dto.VendorResponse;
+import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-import java.util.UUID;
-
-@FeignClient(
-        name = "vendor-server",
-        configuration = VendorClientFeignConfig.class
-)
+@FeignClient(name = "vendor-server", configuration = VendorClientFeignConfig.class)
 public interface VendorClient {
 
-    @GetMapping("/internal/v1/vendors/{vendorId}")
-    VendorResponse getVendor(@PathVariable UUID vendorId);
+  @GetMapping("/internal/v1/vendors/{vendorId}")
+  VendorResponse getVendor(@PathVariable UUID vendorId);
 }

--- a/src/main/java/followMe/hub_server/hub/infrastructure/client/VendorClient.java
+++ b/src/main/java/followMe/hub_server/hub/infrastructure/client/VendorClient.java
@@ -1,0 +1,19 @@
+package followMe.hub_server.hub.infrastructure.client;
+
+import followMe.hub_server.hub.infrastructure.client.config.VendorClientFeignConfig;
+import followMe.hub_server.hub.infrastructure.client.dto.VendorResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.UUID;
+
+@FeignClient(
+        name = "vendor-server",
+        configuration = VendorClientFeignConfig.class
+)
+public interface VendorClient {
+
+    @GetMapping("/internal/v1/vendors/{vendorId}")
+    VendorResponse getVendor(@PathVariable UUID vendorId);
+}

--- a/src/main/java/followMe/hub_server/hub/infrastructure/client/config/VendorClientFeignConfig.java
+++ b/src/main/java/followMe/hub_server/hub/infrastructure/client/config/VendorClientFeignConfig.java
@@ -11,41 +11,37 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 @Configuration
 public class VendorClientFeignConfig {
 
-    private static final String AUTHORIZATION = "Authorization";
+  private static final String AUTHORIZATION = "Authorization";
 
-    @Bean
-    public RequestInterceptor authorizationHeaderForwardInterceptor() {
-        return requestTemplate -> {
-            ServletRequestAttributes attributes =
-                    (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+  @Bean
+  public RequestInterceptor authorizationHeaderForwardInterceptor() {
+    return requestTemplate -> {
+      ServletRequestAttributes attributes =
+          (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
 
-            if (attributes == null) {
-                return;
-            }
+      if (attributes == null) {
+        return;
+      }
 
-            HttpServletRequest request = attributes.getRequest();
-            copyHeader(request, requestTemplate, "Authorization");
-            copyHeader(request, requestTemplate, "X-User-Id");
-            copyHeader(request, requestTemplate, "X-User-Role");
-            copyHeader(request, requestTemplate, "X-Hub-Id");
-            copyHeader(request, requestTemplate, "X-Vendor-Id");
-        };
+      HttpServletRequest request = attributes.getRequest();
+      copyHeader(request, requestTemplate, "Authorization");
+      copyHeader(request, requestTemplate, "X-User-Id");
+      copyHeader(request, requestTemplate, "X-User-Role");
+      copyHeader(request, requestTemplate, "X-Hub-Id");
+      copyHeader(request, requestTemplate, "X-Vendor-Id");
+    };
+  }
+
+  /**
+   * @param request 받았던 요청
+   * @param requestTemplate 보낼 요청
+   * @param headerName 헤더 이름
+   */
+  private void copyHeader(
+      HttpServletRequest request, feign.RequestTemplate requestTemplate, String headerName) {
+    String value = request.getHeader(headerName);
+    if (StringUtils.hasText(value)) {
+      requestTemplate.header(headerName, value);
     }
-
-    /**
-     *
-     * @param request           받았던 요청
-     * @param requestTemplate   보낼 요청
-     * @param headerName        헤더 이름
-     */
-    private void copyHeader(
-            HttpServletRequest request,
-            feign.RequestTemplate requestTemplate,
-            String headerName
-    ) {
-        String value = request.getHeader(headerName);
-        if (StringUtils.hasText(value)) {
-            requestTemplate.header(headerName, value);
-        }
-    }
+  }
 }

--- a/src/main/java/followMe/hub_server/hub/infrastructure/client/config/VendorClientFeignConfig.java
+++ b/src/main/java/followMe/hub_server/hub/infrastructure/client/config/VendorClientFeignConfig.java
@@ -1,0 +1,51 @@
+package followMe.hub_server.hub.infrastructure.client.config;
+
+import feign.RequestInterceptor;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Configuration
+public class VendorClientFeignConfig {
+
+    private static final String AUTHORIZATION = "Authorization";
+
+    @Bean
+    public RequestInterceptor authorizationHeaderForwardInterceptor() {
+        return requestTemplate -> {
+            ServletRequestAttributes attributes =
+                    (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+
+            if (attributes == null) {
+                return;
+            }
+
+            HttpServletRequest request = attributes.getRequest();
+            copyHeader(request, requestTemplate, "Authorization");
+            copyHeader(request, requestTemplate, "X-User-Id");
+            copyHeader(request, requestTemplate, "X-User-Role");
+            copyHeader(request, requestTemplate, "X-Hub-Id");
+            copyHeader(request, requestTemplate, "X-Vendor-Id");
+        };
+    }
+
+    /**
+     *
+     * @param request           받았던 요청
+     * @param requestTemplate   보낼 요청
+     * @param headerName        헤더 이름
+     */
+    private void copyHeader(
+            HttpServletRequest request,
+            feign.RequestTemplate requestTemplate,
+            String headerName
+    ) {
+        String value = request.getHeader(headerName);
+        if (StringUtils.hasText(value)) {
+            requestTemplate.header(headerName, value);
+        }
+    }
+}

--- a/src/main/java/followMe/hub_server/hub/infrastructure/client/dto/VendorResponse.java
+++ b/src/main/java/followMe/hub_server/hub/infrastructure/client/dto/VendorResponse.java
@@ -1,0 +1,18 @@
+package followMe.hub_server.hub.infrastructure.client.dto;
+
+import followMe.hub_server.hub.infrastructure.client.enums.VendorType;
+
+import java.util.UUID;
+
+public record VendorResponse(
+        UUID vendorId,
+        String name,
+        VendorType type,
+        String description,
+        UUID hubId,
+        String ownerName,
+        String address,
+        Double latitude,
+        Double longitude
+) {
+}

--- a/src/main/java/followMe/hub_server/hub/infrastructure/client/dto/VendorResponse.java
+++ b/src/main/java/followMe/hub_server/hub/infrastructure/client/dto/VendorResponse.java
@@ -1,18 +1,15 @@
 package followMe.hub_server.hub.infrastructure.client.dto;
 
 import followMe.hub_server.hub.infrastructure.client.enums.VendorType;
-
 import java.util.UUID;
 
 public record VendorResponse(
-        UUID vendorId,
-        String name,
-        VendorType type,
-        String description,
-        UUID hubId,
-        String ownerName,
-        String address,
-        Double latitude,
-        Double longitude
-) {
-}
+    UUID vendorId,
+    String name,
+    VendorType type,
+    String description,
+    UUID hubId,
+    String ownerName,
+    String address,
+    Double latitude,
+    Double longitude) {}

--- a/src/main/java/followMe/hub_server/hub/infrastructure/client/enums/VendorType.java
+++ b/src/main/java/followMe/hub_server/hub/infrastructure/client/enums/VendorType.java
@@ -1,6 +1,6 @@
 package followMe.hub_server.hub.infrastructure.client.enums;
 
 public enum VendorType {
-    SUPPLIER,
-    BUYER
+  SUPPLIER,
+  BUYER
 }

--- a/src/main/java/followMe/hub_server/hub/infrastructure/client/enums/VendorType.java
+++ b/src/main/java/followMe/hub_server/hub/infrastructure/client/enums/VendorType.java
@@ -1,0 +1,6 @@
+package followMe.hub_server.hub.infrastructure.client.enums;
+
+public enum VendorType {
+    SUPPLIER,
+    BUYER
+}

--- a/src/main/java/followMe/hub_server/hub/presentation/controller/HubController.java
+++ b/src/main/java/followMe/hub_server/hub/presentation/controller/HubController.java
@@ -35,8 +35,7 @@ public class HubController {
       @RequestHeader("X-User-Role") UserRole role,
       @RequestHeader(value = "X-Hub-Id", required = false) UUID hubId,
       @RequestHeader(value = "X-Vendor-Id", required = false) UUID vendorId,
-      @RequestHeader(value = "X-User-Name", required = false) String userName
-      ) {
+      @RequestHeader(value = "X-User-Name", required = false) String userName) {
     return new UserContext(userId, role, hubId, vendorId, userName);
   }
 

--- a/src/main/java/followMe/hub_server/hub/presentation/controller/HubController.java
+++ b/src/main/java/followMe/hub_server/hub/presentation/controller/HubController.java
@@ -34,8 +34,10 @@ public class HubController {
       @RequestHeader("X-User-Id") UUID userId,
       @RequestHeader("X-User-Role") UserRole role,
       @RequestHeader(value = "X-Hub-Id", required = false) UUID hubId,
-      @RequestHeader(value = "X-Vendor-Id", required = false) UUID vendorId) {
-    return new UserContext(userId, role, hubId, vendorId);
+      @RequestHeader(value = "X-Vendor-Id", required = false) UUID vendorId,
+      @RequestHeader(value = "X-User-Name", required = false) String userName
+      ) {
+    return new UserContext(userId, role, hubId, vendorId, userName);
   }
 
   @PostMapping

--- a/src/main/java/followMe/hub_server/hub/presentation/controller/HubRouteController.java
+++ b/src/main/java/followMe/hub_server/hub/presentation/controller/HubRouteController.java
@@ -15,13 +15,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class HubRouteController {
 
-    private final HubRouteService hubRouteService;
+  private final HubRouteService hubRouteService;
 
-    @GetMapping("/route")
-    public HubRouteResDto getRoute(
-            @RequestParam UUID sourceHubId,
-            @RequestParam UUID vendorId) {
-        HubRouteResult result = hubRouteService.getRoute(sourceHubId, vendorId);
-        return HubRouteResDto.from(result);
-    }
+  @GetMapping("/route")
+  public HubRouteResDto getRoute(@RequestParam UUID sourceHubId, @RequestParam UUID vendorId) {
+    HubRouteResult result = hubRouteService.getRoute(sourceHubId, vendorId);
+    return HubRouteResDto.from(result);
+  }
 }

--- a/src/main/java/followMe/hub_server/hub/presentation/controller/HubRouteController.java
+++ b/src/main/java/followMe/hub_server/hub/presentation/controller/HubRouteController.java
@@ -1,0 +1,27 @@
+package followMe.hub_server.hub.presentation.controller;
+
+import followMe.hub_server.hub.application.dto.result.HubRouteResult;
+import followMe.hub_server.hub.application.service.HubRouteService;
+import followMe.hub_server.hub.presentation.dto.response.HubRouteResDto;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/hubs")
+@RequiredArgsConstructor
+public class HubRouteController {
+
+    private final HubRouteService hubRouteService;
+
+    @GetMapping("/route")
+    public HubRouteResDto getRoute(
+            @RequestParam UUID sourceHubId,
+            @RequestParam UUID vendorId) {
+        HubRouteResult result = hubRouteService.getRoute(sourceHubId, vendorId);
+        return HubRouteResDto.from(result);
+    }
+}

--- a/src/main/java/followMe/hub_server/hub/presentation/dto/response/HubRouteNodeResDto.java
+++ b/src/main/java/followMe/hub_server/hub/presentation/dto/response/HubRouteNodeResDto.java
@@ -4,18 +4,8 @@ import followMe.hub_server.hub.application.dto.enums.NodeType;
 import followMe.hub_server.hub.application.dto.result.RouteNodeResult;
 import java.util.UUID;
 
-public record HubRouteNodeResDto(
-        UUID id,
-        NodeType type,
-        String name,
-        int sequence
-) {
-    public static HubRouteNodeResDto from(RouteNodeResult result) {
-        return new HubRouteNodeResDto(
-                result.id(),
-                result.type(),
-                result.name(),
-                result.sequence()
-        );
-    }
+public record HubRouteNodeResDto(UUID id, NodeType type, String name, int sequence) {
+  public static HubRouteNodeResDto from(RouteNodeResult result) {
+    return new HubRouteNodeResDto(result.id(), result.type(), result.name(), result.sequence());
+  }
 }

--- a/src/main/java/followMe/hub_server/hub/presentation/dto/response/HubRouteNodeResDto.java
+++ b/src/main/java/followMe/hub_server/hub/presentation/dto/response/HubRouteNodeResDto.java
@@ -1,0 +1,21 @@
+package followMe.hub_server.hub.presentation.dto.response;
+
+import followMe.hub_server.hub.application.dto.enums.NodeType;
+import followMe.hub_server.hub.application.dto.result.RouteNodeResult;
+import java.util.UUID;
+
+public record HubRouteNodeResDto(
+        UUID id,
+        NodeType type,
+        String name,
+        int sequence
+) {
+    public static HubRouteNodeResDto from(RouteNodeResult result) {
+        return new HubRouteNodeResDto(
+                result.id(),
+                result.type(),
+                result.name(),
+                result.sequence()
+        );
+    }
+}

--- a/src/main/java/followMe/hub_server/hub/presentation/dto/response/HubRouteResDto.java
+++ b/src/main/java/followMe/hub_server/hub/presentation/dto/response/HubRouteResDto.java
@@ -5,11 +5,7 @@ import java.util.List;
 
 public record HubRouteResDto(List<HubRouteNodeResDto> nodes) {
 
-    public static HubRouteResDto from(HubRouteResult result) {
-        return new HubRouteResDto(
-                result.nodes().stream()
-                        .map(HubRouteNodeResDto::from)
-                        .toList()
-        );
-    }
+  public static HubRouteResDto from(HubRouteResult result) {
+    return new HubRouteResDto(result.nodes().stream().map(HubRouteNodeResDto::from).toList());
+  }
 }

--- a/src/main/java/followMe/hub_server/hub/presentation/dto/response/HubRouteResDto.java
+++ b/src/main/java/followMe/hub_server/hub/presentation/dto/response/HubRouteResDto.java
@@ -1,0 +1,15 @@
+package followMe.hub_server.hub.presentation.dto.response;
+
+import followMe.hub_server.hub.application.dto.result.HubRouteResult;
+import java.util.List;
+
+public record HubRouteResDto(List<HubRouteNodeResDto> nodes) {
+
+    public static HubRouteResDto from(HubRouteResult result) {
+        return new HubRouteResDto(
+                result.nodes().stream()
+                        .map(HubRouteNodeResDto::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ spring:
   application:
     name: hub-server
   config:
-    import: 'optional:configserver: '
+    import: 'optional:configserver:'
   cloud:
     config:
       discovery:
@@ -17,11 +17,17 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true
     show-sql: true
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      timeout: 3s
 
 eureka:
   instance:

--- a/src/test/java/followMe/hub_server/hub/HubRouteIntegrationTest.java
+++ b/src/test/java/followMe/hub_server/hub/HubRouteIntegrationTest.java
@@ -36,140 +36,138 @@ import org.springframework.test.web.servlet.MockMvc;
 @AutoConfigureMockMvc(addFilters = false)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @TestPropertySource(
-        properties = {
-                "spring.cloud.config.enabled=false",
-                "spring.config.import=",
-                "eureka.client.enabled=false",
-                "spring.cloud.discovery.enabled=false",
-                "spring.cache.type=simple"
-        }
-)
+    properties = {
+      "spring.cloud.config.enabled=false",
+      "spring.config.import=",
+      "eureka.client.enabled=false",
+      "spring.cloud.discovery.enabled=false",
+      "spring.cache.type=simple"
+    })
 @DisplayName("HubRoute 통합 테스트")
 class HubRouteIntegrationTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+  @Autowired private MockMvc mockMvc;
 
-    @Autowired
-    private HubRepository hubRepository;
+  @Autowired private HubRepository hubRepository;
 
-    @Autowired
-    private CacheManager cacheManager;
+  @Autowired private CacheManager cacheManager;
 
-    @Autowired
-    private HubRouteRepository realHubRouteRepository;
+  @Autowired private HubRouteRepository realHubRouteRepository;
 
-    @MockitoSpyBean
-    private HubRouteRepository hubRouteRepository;
+  @MockitoSpyBean private HubRouteRepository hubRouteRepository;
 
-    @MockitoBean
-    private VendorClient vendorClient;
+  @MockitoBean private VendorClient vendorClient;
 
-    @MockitoBean(name = "auditorAware")
-    private AuditorAware<UUID> auditorAware;
+  @MockitoBean(name = "auditorAware")
+  private AuditorAware<UUID> auditorAware;
 
-    private UUID seoulHubId;
-    private UUID daejeonHubId;
-    private UUID daeguHubId;
-    private UUID vendorId;
+  private UUID seoulHubId;
+  private UUID daejeonHubId;
+  private UUID daeguHubId;
+  private UUID vendorId;
 
-    @BeforeEach
-    void setUp() {
-        when(auditorAware.getCurrentAuditor())
-                .thenReturn(Optional.of(UUID.fromString("11111111-1111-1111-1111-111111111111")));
+  @BeforeEach
+  void setUp() {
+    when(auditorAware.getCurrentAuditor())
+        .thenReturn(Optional.of(UUID.fromString("11111111-1111-1111-1111-111111111111")));
 
-        realHubRouteRepository.deleteAll();
-        hubRepository.deleteAll();
+    realHubRouteRepository.deleteAll();
+    hubRepository.deleteAll();
 
-        if (cacheManager.getCache("hubRoutePath") != null) {
-            cacheManager.getCache("hubRoutePath").clear();
-        }
-
-        Hub seoul = hub("서울특별시 센터", "서울특별시 송파구 송파대로 55");
-        Hub daejeon = hub("대전광역시 센터", "대전 서구 둔산로 100");
-        Hub daegu = hub("대구광역시 센터", "대구 북구 태평로 161");
-
-        seoul = hubRepository.save(seoul);
-        daejeon = hubRepository.save(daejeon);
-        daegu = hubRepository.save(daegu);
-
-        realHubRouteRepository.save(route(seoul, daejeon, "2.0", "140.0"));
-        realHubRouteRepository.save(route(daejeon, daegu, "2.0", "150.0"));
-        realHubRouteRepository.save(route(seoul, daegu, "4.0", "250.0"));
-
-        seoulHubId = seoul.getHubId();
-        daejeonHubId = daejeon.getHubId();
-        daeguHubId = daegu.getHubId();
-        vendorId = UUID.fromString("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb");
-
-        when(vendorClient.getVendor(vendorId)).thenReturn(
-                new VendorResponse(
-                        vendorId,
-                        "대구업체",
-                        VendorType.BUYER,
-                        "설명",
-                        daeguHubId,
-                        "사장님",
-                        "대구 주소",
-                        35.87,
-                        128.60
-                )
-        );
-
-        clearInvocations(hubRouteRepository);
+    if (cacheManager.getCache("hubRoutePath") != null) {
+      cacheManager.getCache("hubRoutePath").clear();
     }
 
-    @Test
-    @DisplayName("경로 조회 API는 HUB 노드들과 마지막 VENDOR 노드를 반환한다")
-    void getRoute_success() throws Exception {
-        mockMvc.perform(get("/api/hubs/route")
-                        .param("sourceHubId", seoulHubId.toString())
-                        .param("vendorId", vendorId.toString()))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.nodes.length()").value(4))
-                .andExpect(jsonPath("$.nodes[0].id").value(seoulHubId.toString()))
-                .andExpect(jsonPath("$.nodes[0].type").value("HUB"))
-                .andExpect(jsonPath("$.nodes[1].id").value(daejeonHubId.toString()))
-                .andExpect(jsonPath("$.nodes[1].type").value("HUB"))
-                .andExpect(jsonPath("$.nodes[2].id").value(daeguHubId.toString()))
-                .andExpect(jsonPath("$.nodes[2].type").value("HUB"))
-                .andExpect(jsonPath("$.nodes[3].id").value(vendorId.toString()))
-                .andExpect(jsonPath("$.nodes[3].type").value("VENDOR"))
-                .andExpect(jsonPath("$.nodes[3].name").value("대구업체"))
-                .andExpect(jsonPath("$.nodes[3].sequence").value(4));
-    }
+    Hub seoul = hub("서울특별시 센터", "서울특별시 송파구 송파대로 55");
+    Hub daejeon = hub("대전광역시 센터", "대전 서구 둔산로 100");
+    Hub daegu = hub("대구광역시 센터", "대구 북구 태평로 161");
 
-    @Test
-    @DisplayName("같은 출발지와 목적지로 두 번 조회하면 hub path 캐시가 적용된다")
-    void getRoute_cacheApplied() throws Exception {
-        mockMvc.perform(get("/api/hubs/route")
-                        .param("sourceHubId", seoulHubId.toString())
-                        .param("vendorId", vendorId.toString()))
-                .andExpect(status().isOk());
+    seoul = hubRepository.save(seoul);
+    daejeon = hubRepository.save(daejeon);
+    daegu = hubRepository.save(daegu);
 
-        mockMvc.perform(get("/api/hubs/route")
-                        .param("sourceHubId", seoulHubId.toString())
-                        .param("vendorId", vendorId.toString()))
-                .andExpect(status().isOk());
+    realHubRouteRepository.save(route(seoul, daejeon, "2.0", "140.0"));
+    realHubRouteRepository.save(route(daejeon, daegu, "2.0", "150.0"));
+    realHubRouteRepository.save(route(seoul, daegu, "4.0", "250.0"));
 
-        verify(hubRouteRepository, times(1)).findAll();
-    }
+    seoulHubId = seoul.getHubId();
+    daejeonHubId = daejeon.getHubId();
+    daeguHubId = daegu.getHubId();
+    vendorId = UUID.fromString("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb");
 
-    private Hub hub(String name, String address) {
-        return Hub.builder()
-                .hubName(name)
-                .address(address)
-                .latitude(new BigDecimal("37.0000000"))
-                .longitude(new BigDecimal("127.0000000"))
-                .build();
-    }
+    when(vendorClient.getVendor(vendorId))
+        .thenReturn(
+            new VendorResponse(
+                vendorId,
+                "대구업체",
+                VendorType.BUYER,
+                "설명",
+                daeguHubId,
+                "사장님",
+                "대구 주소",
+                35.87,
+                128.60));
 
-    private HubRoute route(Hub origin, Hub destination, String duration, String distance) {
-        return HubRoute.builder()
-                .originHub(origin)
-                .destinationHub(destination)
-                .duration(new BigDecimal(duration))
-                .distance(new BigDecimal(distance))
-                .build();
-    }
+    clearInvocations(hubRouteRepository);
+  }
+
+  @Test
+  @DisplayName("경로 조회 API는 HUB 노드들과 마지막 VENDOR 노드를 반환한다")
+  void getRoute_success() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/hubs/route")
+                .param("sourceHubId", seoulHubId.toString())
+                .param("vendorId", vendorId.toString()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.nodes.length()").value(4))
+        .andExpect(jsonPath("$.nodes[0].id").value(seoulHubId.toString()))
+        .andExpect(jsonPath("$.nodes[0].type").value("HUB"))
+        .andExpect(jsonPath("$.nodes[1].id").value(daejeonHubId.toString()))
+        .andExpect(jsonPath("$.nodes[1].type").value("HUB"))
+        .andExpect(jsonPath("$.nodes[2].id").value(daeguHubId.toString()))
+        .andExpect(jsonPath("$.nodes[2].type").value("HUB"))
+        .andExpect(jsonPath("$.nodes[3].id").value(vendorId.toString()))
+        .andExpect(jsonPath("$.nodes[3].type").value("VENDOR"))
+        .andExpect(jsonPath("$.nodes[3].name").value("대구업체"))
+        .andExpect(jsonPath("$.nodes[3].sequence").value(4));
+  }
+
+  @Test
+  @DisplayName("같은 출발지와 목적지로 두 번 조회하면 hub path 캐시가 적용된다")
+  void getRoute_cacheApplied() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/hubs/route")
+                .param("sourceHubId", seoulHubId.toString())
+                .param("vendorId", vendorId.toString()))
+        .andExpect(status().isOk());
+
+    mockMvc
+        .perform(
+            get("/api/hubs/route")
+                .param("sourceHubId", seoulHubId.toString())
+                .param("vendorId", vendorId.toString()))
+        .andExpect(status().isOk());
+
+    verify(hubRouteRepository, times(1)).findAll();
+  }
+
+  private Hub hub(String name, String address) {
+    return Hub.builder()
+        .hubName(name)
+        .address(address)
+        .latitude(new BigDecimal("37.0000000"))
+        .longitude(new BigDecimal("127.0000000"))
+        .build();
+  }
+
+  private HubRoute route(Hub origin, Hub destination, String duration, String distance) {
+    return HubRoute.builder()
+        .originHub(origin)
+        .destinationHub(destination)
+        .duration(new BigDecimal(duration))
+        .distance(new BigDecimal(distance))
+        .build();
+  }
 }

--- a/src/test/java/followMe/hub_server/hub/HubRouteIntegrationTest.java
+++ b/src/test/java/followMe/hub_server/hub/HubRouteIntegrationTest.java
@@ -1,0 +1,175 @@
+package followMe.hub_server.hub;
+
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import followMe.hub_server.hub.domain.entity.Hub;
+import followMe.hub_server.hub.domain.entity.HubRoute;
+import followMe.hub_server.hub.domain.repository.HubRepository;
+import followMe.hub_server.hub.domain.repository.HubRouteRepository;
+import followMe.hub_server.hub.infrastructure.client.VendorClient;
+import followMe.hub_server.hub.infrastructure.client.dto.VendorResponse;
+import followMe.hub_server.hub.infrastructure.client.enums.VendorType;
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(
+        properties = {
+                "spring.cloud.config.enabled=false",
+                "spring.config.import=",
+                "eureka.client.enabled=false",
+                "spring.cloud.discovery.enabled=false",
+                "spring.cache.type=simple"
+        }
+)
+@DisplayName("HubRoute 통합 테스트")
+class HubRouteIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private HubRepository hubRepository;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @Autowired
+    private HubRouteRepository realHubRouteRepository;
+
+    @MockitoSpyBean
+    private HubRouteRepository hubRouteRepository;
+
+    @MockitoBean
+    private VendorClient vendorClient;
+
+    @MockitoBean(name = "auditorAware")
+    private AuditorAware<UUID> auditorAware;
+
+    private UUID seoulHubId;
+    private UUID daejeonHubId;
+    private UUID daeguHubId;
+    private UUID vendorId;
+
+    @BeforeEach
+    void setUp() {
+        when(auditorAware.getCurrentAuditor())
+                .thenReturn(Optional.of(UUID.fromString("11111111-1111-1111-1111-111111111111")));
+
+        realHubRouteRepository.deleteAll();
+        hubRepository.deleteAll();
+
+        if (cacheManager.getCache("hubRoutePath") != null) {
+            cacheManager.getCache("hubRoutePath").clear();
+        }
+
+        Hub seoul = hub("서울특별시 센터", "서울특별시 송파구 송파대로 55");
+        Hub daejeon = hub("대전광역시 센터", "대전 서구 둔산로 100");
+        Hub daegu = hub("대구광역시 센터", "대구 북구 태평로 161");
+
+        seoul = hubRepository.save(seoul);
+        daejeon = hubRepository.save(daejeon);
+        daegu = hubRepository.save(daegu);
+
+        realHubRouteRepository.save(route(seoul, daejeon, "2.0", "140.0"));
+        realHubRouteRepository.save(route(daejeon, daegu, "2.0", "150.0"));
+        realHubRouteRepository.save(route(seoul, daegu, "4.0", "250.0"));
+
+        seoulHubId = seoul.getHubId();
+        daejeonHubId = daejeon.getHubId();
+        daeguHubId = daegu.getHubId();
+        vendorId = UUID.fromString("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb");
+
+        when(vendorClient.getVendor(vendorId)).thenReturn(
+                new VendorResponse(
+                        vendorId,
+                        "대구업체",
+                        VendorType.BUYER,
+                        "설명",
+                        daeguHubId,
+                        "사장님",
+                        "대구 주소",
+                        35.87,
+                        128.60
+                )
+        );
+
+        clearInvocations(hubRouteRepository);
+    }
+
+    @Test
+    @DisplayName("경로 조회 API는 HUB 노드들과 마지막 VENDOR 노드를 반환한다")
+    void getRoute_success() throws Exception {
+        mockMvc.perform(get("/api/hubs/route")
+                        .param("sourceHubId", seoulHubId.toString())
+                        .param("vendorId", vendorId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nodes.length()").value(4))
+                .andExpect(jsonPath("$.nodes[0].id").value(seoulHubId.toString()))
+                .andExpect(jsonPath("$.nodes[0].type").value("HUB"))
+                .andExpect(jsonPath("$.nodes[1].id").value(daejeonHubId.toString()))
+                .andExpect(jsonPath("$.nodes[1].type").value("HUB"))
+                .andExpect(jsonPath("$.nodes[2].id").value(daeguHubId.toString()))
+                .andExpect(jsonPath("$.nodes[2].type").value("HUB"))
+                .andExpect(jsonPath("$.nodes[3].id").value(vendorId.toString()))
+                .andExpect(jsonPath("$.nodes[3].type").value("VENDOR"))
+                .andExpect(jsonPath("$.nodes[3].name").value("대구업체"))
+                .andExpect(jsonPath("$.nodes[3].sequence").value(4));
+    }
+
+    @Test
+    @DisplayName("같은 출발지와 목적지로 두 번 조회하면 hub path 캐시가 적용된다")
+    void getRoute_cacheApplied() throws Exception {
+        mockMvc.perform(get("/api/hubs/route")
+                        .param("sourceHubId", seoulHubId.toString())
+                        .param("vendorId", vendorId.toString()))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/hubs/route")
+                        .param("sourceHubId", seoulHubId.toString())
+                        .param("vendorId", vendorId.toString()))
+                .andExpect(status().isOk());
+
+        verify(hubRouteRepository, times(1)).findAll();
+    }
+
+    private Hub hub(String name, String address) {
+        return Hub.builder()
+                .hubName(name)
+                .address(address)
+                .latitude(new BigDecimal("37.0000000"))
+                .longitude(new BigDecimal("127.0000000"))
+                .build();
+    }
+
+    private HubRoute route(Hub origin, Hub destination, String duration, String distance) {
+        return HubRoute.builder()
+                .originHub(origin)
+                .destinationHub(destination)
+                .duration(new BigDecimal(duration))
+                .distance(new BigDecimal(distance))
+                .build();
+    }
+}

--- a/src/test/java/followMe/hub_server/hub/application/service/HubRoutePathQueryServiceTest.java
+++ b/src/test/java/followMe/hub_server/hub/application/service/HubRoutePathQueryServiceTest.java
@@ -28,105 +28,103 @@ import org.springframework.test.util.ReflectionTestUtils;
 @DisplayName("HubRoutePathQueryService 단위 테스트")
 class HubRoutePathQueryServiceTest {
 
-    @Mock
-    private HubRepository hubRepository;
+  @Mock private HubRepository hubRepository;
 
-    @Mock
-    private HubRouteRepository hubRouteRepository;
+  @Mock private HubRouteRepository hubRouteRepository;
 
-    @InjectMocks
-    private HubRoutePathQueryService hubRoutePathQueryService;
+  @InjectMocks private HubRoutePathQueryService hubRoutePathQueryService;
 
-    @Test
-    @DisplayName("200km 이상 직행 경로는 무시하고 200km 미만 릴레이 경로를 찾는다")
-    void getHubPath_withRelayRoute_success() {
-        // given
-        Hub seoul = hub("11111111-1111-1111-1111-111111111111", "서울특별시 센터");
-        Hub daejeon = hub("88888888-8888-8888-8888-888888888888", "대전광역시 센터");
-        Hub daegu = hub("55555555-5555-5555-5555-555555555555", "대구광역시 센터");
+  @Test
+  @DisplayName("200km 이상 직행 경로는 무시하고 200km 미만 릴레이 경로를 찾는다")
+  void getHubPath_withRelayRoute_success() {
+    // given
+    Hub seoul = hub("11111111-1111-1111-1111-111111111111", "서울특별시 센터");
+    Hub daejeon = hub("88888888-8888-8888-8888-888888888888", "대전광역시 센터");
+    Hub daegu = hub("55555555-5555-5555-5555-555555555555", "대구광역시 센터");
 
-        HubRoute directOver200 = route(seoul, daegu, "4.0", "250.0");
-        HubRoute seoulToDaejeon = route(seoul, daejeon, "2.0", "140.0");
-        HubRoute daejeonToDaegu = route(daejeon, daegu, "2.0", "150.0");
+    HubRoute directOver200 = route(seoul, daegu, "4.0", "250.0");
+    HubRoute seoulToDaejeon = route(seoul, daejeon, "2.0", "140.0");
+    HubRoute daejeonToDaegu = route(daejeon, daegu, "2.0", "150.0");
 
-        when(hubRepository.findById(seoul.getHubId())).thenReturn(Optional.of(seoul));
-        when(hubRepository.findById(daejeon.getHubId())).thenReturn(Optional.of(daejeon));
-        when(hubRepository.findById(daegu.getHubId())).thenReturn(Optional.of(daegu));
-        when(hubRouteRepository.findAll())
-                .thenReturn(List.of(directOver200, seoulToDaejeon, daejeonToDaegu));
+    when(hubRepository.findById(seoul.getHubId())).thenReturn(Optional.of(seoul));
+    when(hubRepository.findById(daejeon.getHubId())).thenReturn(Optional.of(daejeon));
+    when(hubRepository.findById(daegu.getHubId())).thenReturn(Optional.of(daegu));
+    when(hubRouteRepository.findAll())
+        .thenReturn(List.of(directOver200, seoulToDaejeon, daejeonToDaegu));
 
-        // when
-        HubPathResult result = hubRoutePathQueryService.getHubPath(seoul.getHubId(), daegu.getHubId());
+    // when
+    HubPathResult result = hubRoutePathQueryService.getHubPath(seoul.getHubId(), daegu.getHubId());
 
-        // then
-        assertAll(
-                () -> assertThat(result.hubNodes()).hasSize(3),
-                () -> assertThat(result.hubNodes().get(0).id()).isEqualTo(seoul.getHubId()),
-                () -> assertThat(result.hubNodes().get(0).type()).isEqualTo(NodeType.HUB),
-                () -> assertThat(result.hubNodes().get(1).id()).isEqualTo(daejeon.getHubId()),
-                () -> assertThat(result.hubNodes().get(2).id()).isEqualTo(daegu.getHubId())
-        );
-    }
+    // then
+    assertAll(
+        () -> assertThat(result.hubNodes()).hasSize(3),
+        () -> assertThat(result.hubNodes().get(0).id()).isEqualTo(seoul.getHubId()),
+        () -> assertThat(result.hubNodes().get(0).type()).isEqualTo(NodeType.HUB),
+        () -> assertThat(result.hubNodes().get(1).id()).isEqualTo(daejeon.getHubId()),
+        () -> assertThat(result.hubNodes().get(2).id()).isEqualTo(daegu.getHubId()));
+  }
 
-    @Test
-    @DisplayName("저장된 단방향 경로를 역방향으로도 사용할 수 있다")
-    void getHubPath_reverseDirection_success() {
-        // given
-        Hub seoul = hub("11111111-1111-1111-1111-111111111111", "서울특별시 센터");
-        Hub daejeon = hub("88888888-8888-8888-8888-888888888888", "대전광역시 센터");
+  @Test
+  @DisplayName("저장된 단방향 경로를 역방향으로도 사용할 수 있다")
+  void getHubPath_reverseDirection_success() {
+    // given
+    Hub seoul = hub("11111111-1111-1111-1111-111111111111", "서울특별시 센터");
+    Hub daejeon = hub("88888888-8888-8888-8888-888888888888", "대전광역시 센터");
 
-        HubRoute seoulToDaejeon = route(seoul, daejeon, "2.0", "140.0");
+    HubRoute seoulToDaejeon = route(seoul, daejeon, "2.0", "140.0");
 
-        when(hubRepository.findById(seoul.getHubId())).thenReturn(Optional.of(seoul));
-        when(hubRepository.findById(daejeon.getHubId())).thenReturn(Optional.of(daejeon));
-        when(hubRouteRepository.findAll()).thenReturn(List.of(seoulToDaejeon));
+    when(hubRepository.findById(seoul.getHubId())).thenReturn(Optional.of(seoul));
+    when(hubRepository.findById(daejeon.getHubId())).thenReturn(Optional.of(daejeon));
+    when(hubRouteRepository.findAll()).thenReturn(List.of(seoulToDaejeon));
 
-        // when
-        HubPathResult result = hubRoutePathQueryService.getHubPath(daejeon.getHubId(), seoul.getHubId());
+    // when
+    HubPathResult result =
+        hubRoutePathQueryService.getHubPath(daejeon.getHubId(), seoul.getHubId());
 
-        // then
-        assertAll(
-                () -> assertThat(result.hubNodes()).hasSize(2),
-                () -> assertThat(result.hubNodes().get(0).id()).isEqualTo(daejeon.getHubId()),
-                () -> assertThat(result.hubNodes().get(1).id()).isEqualTo(seoul.getHubId())
-        );
-    }
+    // then
+    assertAll(
+        () -> assertThat(result.hubNodes()).hasSize(2),
+        () -> assertThat(result.hubNodes().get(0).id()).isEqualTo(daejeon.getHubId()),
+        () -> assertThat(result.hubNodes().get(1).id()).isEqualTo(seoul.getHubId()));
+  }
 
-    @Test
-    @DisplayName("200km 미만으로 도달 가능한 경로가 없으면 예외가 발생한다")
-    void getHubPath_noAvailableRoute_throwsException() {
-        // given
-        Hub seoul = hub("11111111-1111-1111-1111-111111111111", "서울특별시 센터");
-        Hub busan = hub("44444444-4444-4444-4444-444444444444", "부산광역시 센터");
+  @Test
+  @DisplayName("200km 미만으로 도달 가능한 경로가 없으면 예외가 발생한다")
+  void getHubPath_noAvailableRoute_throwsException() {
+    // given
+    Hub seoul = hub("11111111-1111-1111-1111-111111111111", "서울특별시 센터");
+    Hub busan = hub("44444444-4444-4444-4444-444444444444", "부산광역시 센터");
 
-        HubRoute over200Only = route(seoul, busan, "5.0", "320.0");
+    HubRoute over200Only = route(seoul, busan, "5.0", "320.0");
 
-        when(hubRepository.findById(seoul.getHubId())).thenReturn(Optional.of(seoul));
-        when(hubRepository.findById(busan.getHubId())).thenReturn(Optional.of(busan));
-        when(hubRouteRepository.findAll()).thenReturn(List.of(over200Only));
+    when(hubRepository.findById(seoul.getHubId())).thenReturn(Optional.of(seoul));
+    when(hubRepository.findById(busan.getHubId())).thenReturn(Optional.of(busan));
+    when(hubRouteRepository.findAll()).thenReturn(List.of(over200Only));
 
-        // when // then
-        assertThatThrownBy(() -> hubRoutePathQueryService.getHubPath(seoul.getHubId(), busan.getHubId()))
-                .isInstanceOf(HubRouteNotFoundException.class);
-    }
+    // when // then
+    assertThatThrownBy(
+            () -> hubRoutePathQueryService.getHubPath(seoul.getHubId(), busan.getHubId()))
+        .isInstanceOf(HubRouteNotFoundException.class);
+  }
 
-    private Hub hub(String id, String name) {
-        Hub hub = Hub.builder()
-                .hubName(name)
-                .address(name + " 주소")
-                .latitude(new BigDecimal("37.0000000"))
-                .longitude(new BigDecimal("127.0000000"))
-                .build();
-        ReflectionTestUtils.setField(hub, "hubId", UUID.fromString(id));
-        return hub;
-    }
+  private Hub hub(String id, String name) {
+    Hub hub =
+        Hub.builder()
+            .hubName(name)
+            .address(name + " 주소")
+            .latitude(new BigDecimal("37.0000000"))
+            .longitude(new BigDecimal("127.0000000"))
+            .build();
+    ReflectionTestUtils.setField(hub, "hubId", UUID.fromString(id));
+    return hub;
+  }
 
-    private HubRoute route(Hub origin, Hub destination, String duration, String distance) {
-        return HubRoute.builder()
-                .originHub(origin)
-                .destinationHub(destination)
-                .duration(new BigDecimal(duration))
-                .distance(new BigDecimal(distance))
-                .build();
-    }
+  private HubRoute route(Hub origin, Hub destination, String duration, String distance) {
+    return HubRoute.builder()
+        .originHub(origin)
+        .destinationHub(destination)
+        .duration(new BigDecimal(duration))
+        .distance(new BigDecimal(distance))
+        .build();
+  }
 }

--- a/src/test/java/followMe/hub_server/hub/application/service/HubRoutePathQueryServiceTest.java
+++ b/src/test/java/followMe/hub_server/hub/application/service/HubRoutePathQueryServiceTest.java
@@ -1,0 +1,132 @@
+package followMe.hub_server.hub.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.when;
+
+import followMe.hub_server.hub.application.dto.enums.NodeType;
+import followMe.hub_server.hub.application.dto.result.HubPathResult;
+import followMe.hub_server.hub.domain.entity.Hub;
+import followMe.hub_server.hub.domain.entity.HubRoute;
+import followMe.hub_server.hub.domain.repository.HubRepository;
+import followMe.hub_server.hub.domain.repository.HubRouteRepository;
+import followMe.hub_server.hub.exception.detail.HubRouteNotFoundException;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("HubRoutePathQueryService 단위 테스트")
+class HubRoutePathQueryServiceTest {
+
+    @Mock
+    private HubRepository hubRepository;
+
+    @Mock
+    private HubRouteRepository hubRouteRepository;
+
+    @InjectMocks
+    private HubRoutePathQueryService hubRoutePathQueryService;
+
+    @Test
+    @DisplayName("200km 이상 직행 경로는 무시하고 200km 미만 릴레이 경로를 찾는다")
+    void getHubPath_withRelayRoute_success() {
+        // given
+        Hub seoul = hub("11111111-1111-1111-1111-111111111111", "서울특별시 센터");
+        Hub daejeon = hub("88888888-8888-8888-8888-888888888888", "대전광역시 센터");
+        Hub daegu = hub("55555555-5555-5555-5555-555555555555", "대구광역시 센터");
+
+        HubRoute directOver200 = route(seoul, daegu, "4.0", "250.0");
+        HubRoute seoulToDaejeon = route(seoul, daejeon, "2.0", "140.0");
+        HubRoute daejeonToDaegu = route(daejeon, daegu, "2.0", "150.0");
+
+        when(hubRepository.findById(seoul.getHubId())).thenReturn(Optional.of(seoul));
+        when(hubRepository.findById(daejeon.getHubId())).thenReturn(Optional.of(daejeon));
+        when(hubRepository.findById(daegu.getHubId())).thenReturn(Optional.of(daegu));
+        when(hubRouteRepository.findAll())
+                .thenReturn(List.of(directOver200, seoulToDaejeon, daejeonToDaegu));
+
+        // when
+        HubPathResult result = hubRoutePathQueryService.getHubPath(seoul.getHubId(), daegu.getHubId());
+
+        // then
+        assertAll(
+                () -> assertThat(result.hubNodes()).hasSize(3),
+                () -> assertThat(result.hubNodes().get(0).id()).isEqualTo(seoul.getHubId()),
+                () -> assertThat(result.hubNodes().get(0).type()).isEqualTo(NodeType.HUB),
+                () -> assertThat(result.hubNodes().get(1).id()).isEqualTo(daejeon.getHubId()),
+                () -> assertThat(result.hubNodes().get(2).id()).isEqualTo(daegu.getHubId())
+        );
+    }
+
+    @Test
+    @DisplayName("저장된 단방향 경로를 역방향으로도 사용할 수 있다")
+    void getHubPath_reverseDirection_success() {
+        // given
+        Hub seoul = hub("11111111-1111-1111-1111-111111111111", "서울특별시 센터");
+        Hub daejeon = hub("88888888-8888-8888-8888-888888888888", "대전광역시 센터");
+
+        HubRoute seoulToDaejeon = route(seoul, daejeon, "2.0", "140.0");
+
+        when(hubRepository.findById(seoul.getHubId())).thenReturn(Optional.of(seoul));
+        when(hubRepository.findById(daejeon.getHubId())).thenReturn(Optional.of(daejeon));
+        when(hubRouteRepository.findAll()).thenReturn(List.of(seoulToDaejeon));
+
+        // when
+        HubPathResult result = hubRoutePathQueryService.getHubPath(daejeon.getHubId(), seoul.getHubId());
+
+        // then
+        assertAll(
+                () -> assertThat(result.hubNodes()).hasSize(2),
+                () -> assertThat(result.hubNodes().get(0).id()).isEqualTo(daejeon.getHubId()),
+                () -> assertThat(result.hubNodes().get(1).id()).isEqualTo(seoul.getHubId())
+        );
+    }
+
+    @Test
+    @DisplayName("200km 미만으로 도달 가능한 경로가 없으면 예외가 발생한다")
+    void getHubPath_noAvailableRoute_throwsException() {
+        // given
+        Hub seoul = hub("11111111-1111-1111-1111-111111111111", "서울특별시 센터");
+        Hub busan = hub("44444444-4444-4444-4444-444444444444", "부산광역시 센터");
+
+        HubRoute over200Only = route(seoul, busan, "5.0", "320.0");
+
+        when(hubRepository.findById(seoul.getHubId())).thenReturn(Optional.of(seoul));
+        when(hubRepository.findById(busan.getHubId())).thenReturn(Optional.of(busan));
+        when(hubRouteRepository.findAll()).thenReturn(List.of(over200Only));
+
+        // when // then
+        assertThatThrownBy(() -> hubRoutePathQueryService.getHubPath(seoul.getHubId(), busan.getHubId()))
+                .isInstanceOf(HubRouteNotFoundException.class);
+    }
+
+    private Hub hub(String id, String name) {
+        Hub hub = Hub.builder()
+                .hubName(name)
+                .address(name + " 주소")
+                .latitude(new BigDecimal("37.0000000"))
+                .longitude(new BigDecimal("127.0000000"))
+                .build();
+        ReflectionTestUtils.setField(hub, "hubId", UUID.fromString(id));
+        return hub;
+    }
+
+    private HubRoute route(Hub origin, Hub destination, String duration, String distance) {
+        return HubRoute.builder()
+                .originHub(origin)
+                .destinationHub(destination)
+                .duration(new BigDecimal(duration))
+                .distance(new BigDecimal(distance))
+                .build();
+    }
+}

--- a/src/test/java/followMe/hub_server/hub/application/service/HubRouteServiceImplTest.java
+++ b/src/test/java/followMe/hub_server/hub/application/service/HubRouteServiceImplTest.java
@@ -1,0 +1,122 @@
+package followMe.hub_server.hub.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.when;
+
+import followMe.hub_server.hub.application.dto.enums.NodeType;
+import followMe.hub_server.hub.application.dto.result.HubPathResult;
+import followMe.hub_server.hub.application.dto.result.HubRouteResult;
+import followMe.hub_server.hub.application.dto.result.RouteNodeResult;
+import followMe.hub_server.hub.exception.detail.InvalidVendorResponseException;
+import followMe.hub_server.hub.exception.detail.VendorNotFoundException;
+import followMe.hub_server.hub.infrastructure.client.VendorClient;
+import followMe.hub_server.hub.infrastructure.client.dto.VendorResponse;
+import followMe.hub_server.hub.infrastructure.client.enums.VendorType;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("HubRouteServiceImpl 단위 테스트")
+class HubRouteServiceImplTest {
+
+    @Mock
+    private VendorClient vendorClient;
+
+    @Mock
+    private HubRoutePathQueryService hubRoutePathQueryService;
+
+    @InjectMocks
+    private HubRouteServiceImpl hubRouteService;
+
+    @Test
+    @DisplayName("vendor 정보와 hub path를 합쳐 최종 route를 반환한다")
+    void getRoute_success() {
+        // given
+        UUID sourceHubId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        UUID middleHubId = UUID.fromString("88888888-8888-8888-8888-888888888888");
+        UUID destinationHubId = UUID.fromString("55555555-5555-5555-5555-555555555555");
+        UUID vendorId = UUID.fromString("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb");
+
+        VendorResponse vendorResponse = new VendorResponse(
+                vendorId,
+                "대구업체",
+                VendorType.BUYER,
+                "설명",
+                destinationHubId,
+                "사장님",
+                "대구 주소",
+                35.87,
+                128.60
+        );
+
+        HubPathResult hubPathResult = new HubPathResult(List.of(
+                new RouteNodeResult(sourceHubId, NodeType.HUB, "서울특별시 센터", 1),
+                new RouteNodeResult(middleHubId, NodeType.HUB, "대전광역시 센터", 2),
+                new RouteNodeResult(destinationHubId, NodeType.HUB, "대구광역시 센터", 3)
+        ));
+
+        when(vendorClient.getVendor(vendorId)).thenReturn(vendorResponse);
+        when(hubRoutePathQueryService.getHubPath(sourceHubId, destinationHubId)).thenReturn(hubPathResult);
+
+        // when
+        HubRouteResult result = hubRouteService.getRoute(sourceHubId, vendorId);
+
+        // then
+        assertAll(
+                () -> assertThat(result.nodes()).hasSize(4),
+                () -> assertThat(result.nodes().get(0).type()).isEqualTo(NodeType.HUB),
+                () -> assertThat(result.nodes().get(3).id()).isEqualTo(vendorId),
+                () -> assertThat(result.nodes().get(3).type()).isEqualTo(NodeType.VENDOR),
+                () -> assertThat(result.nodes().get(3).name()).isEqualTo("대구업체"),
+                () -> assertThat(result.nodes().get(3).sequence()).isEqualTo(4)
+        );
+    }
+
+    @Test
+    @DisplayName("vendor 응답이 null이면 예외가 발생한다")
+    void getRoute_vendorNull_throwsException() {
+        // given
+        UUID sourceHubId = UUID.randomUUID();
+        UUID vendorId = UUID.randomUUID();
+
+        when(vendorClient.getVendor(vendorId)).thenReturn(null);
+
+        // when // then
+        assertThatThrownBy(() -> hubRouteService.getRoute(sourceHubId, vendorId))
+                .isInstanceOf(VendorNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("vendor 응답의 hubId가 null이면 예외가 발생한다")
+    void getRoute_vendorHubIdNull_throwsException() {
+        // given
+        UUID sourceHubId = UUID.randomUUID();
+        UUID vendorId = UUID.randomUUID();
+
+        VendorResponse vendorResponse = new VendorResponse(
+                vendorId,
+                "허브없는업체",
+                VendorType.BUYER,
+                "설명",
+                null,
+                "사장님",
+                "주소",
+                0.0,
+                0.0
+        );
+
+        when(vendorClient.getVendor(vendorId)).thenReturn(vendorResponse);
+
+        // when // then
+        assertThatThrownBy(() -> hubRouteService.getRoute(sourceHubId, vendorId))
+                .isInstanceOf(InvalidVendorResponseException.class);
+    }
+}

--- a/src/test/java/followMe/hub_server/hub/application/service/HubRouteServiceImplTest.java
+++ b/src/test/java/followMe/hub_server/hub/application/service/HubRouteServiceImplTest.java
@@ -27,96 +27,85 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @DisplayName("HubRouteServiceImpl 단위 테스트")
 class HubRouteServiceImplTest {
 
-    @Mock
-    private VendorClient vendorClient;
+  @Mock private VendorClient vendorClient;
 
-    @Mock
-    private HubRoutePathQueryService hubRoutePathQueryService;
+  @Mock private HubRoutePathQueryService hubRoutePathQueryService;
 
-    @InjectMocks
-    private HubRouteServiceImpl hubRouteService;
+  @InjectMocks private HubRouteServiceImpl hubRouteService;
 
-    @Test
-    @DisplayName("vendor 정보와 hub path를 합쳐 최종 route를 반환한다")
-    void getRoute_success() {
-        // given
-        UUID sourceHubId = UUID.fromString("11111111-1111-1111-1111-111111111111");
-        UUID middleHubId = UUID.fromString("88888888-8888-8888-8888-888888888888");
-        UUID destinationHubId = UUID.fromString("55555555-5555-5555-5555-555555555555");
-        UUID vendorId = UUID.fromString("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb");
+  @Test
+  @DisplayName("vendor 정보와 hub path를 합쳐 최종 route를 반환한다")
+  void getRoute_success() {
+    // given
+    UUID sourceHubId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    UUID middleHubId = UUID.fromString("88888888-8888-8888-8888-888888888888");
+    UUID destinationHubId = UUID.fromString("55555555-5555-5555-5555-555555555555");
+    UUID vendorId = UUID.fromString("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb");
 
-        VendorResponse vendorResponse = new VendorResponse(
-                vendorId,
-                "대구업체",
-                VendorType.BUYER,
-                "설명",
-                destinationHubId,
-                "사장님",
-                "대구 주소",
-                35.87,
-                128.60
-        );
+    VendorResponse vendorResponse =
+        new VendorResponse(
+            vendorId,
+            "대구업체",
+            VendorType.BUYER,
+            "설명",
+            destinationHubId,
+            "사장님",
+            "대구 주소",
+            35.87,
+            128.60);
 
-        HubPathResult hubPathResult = new HubPathResult(List.of(
+    HubPathResult hubPathResult =
+        new HubPathResult(
+            List.of(
                 new RouteNodeResult(sourceHubId, NodeType.HUB, "서울특별시 센터", 1),
                 new RouteNodeResult(middleHubId, NodeType.HUB, "대전광역시 센터", 2),
-                new RouteNodeResult(destinationHubId, NodeType.HUB, "대구광역시 센터", 3)
-        ));
+                new RouteNodeResult(destinationHubId, NodeType.HUB, "대구광역시 센터", 3)));
 
-        when(vendorClient.getVendor(vendorId)).thenReturn(vendorResponse);
-        when(hubRoutePathQueryService.getHubPath(sourceHubId, destinationHubId)).thenReturn(hubPathResult);
+    when(vendorClient.getVendor(vendorId)).thenReturn(vendorResponse);
+    when(hubRoutePathQueryService.getHubPath(sourceHubId, destinationHubId))
+        .thenReturn(hubPathResult);
 
-        // when
-        HubRouteResult result = hubRouteService.getRoute(sourceHubId, vendorId);
+    // when
+    HubRouteResult result = hubRouteService.getRoute(sourceHubId, vendorId);
 
-        // then
-        assertAll(
-                () -> assertThat(result.nodes()).hasSize(4),
-                () -> assertThat(result.nodes().get(0).type()).isEqualTo(NodeType.HUB),
-                () -> assertThat(result.nodes().get(3).id()).isEqualTo(vendorId),
-                () -> assertThat(result.nodes().get(3).type()).isEqualTo(NodeType.VENDOR),
-                () -> assertThat(result.nodes().get(3).name()).isEqualTo("대구업체"),
-                () -> assertThat(result.nodes().get(3).sequence()).isEqualTo(4)
-        );
-    }
+    // then
+    assertAll(
+        () -> assertThat(result.nodes()).hasSize(4),
+        () -> assertThat(result.nodes().get(0).type()).isEqualTo(NodeType.HUB),
+        () -> assertThat(result.nodes().get(3).id()).isEqualTo(vendorId),
+        () -> assertThat(result.nodes().get(3).type()).isEqualTo(NodeType.VENDOR),
+        () -> assertThat(result.nodes().get(3).name()).isEqualTo("대구업체"),
+        () -> assertThat(result.nodes().get(3).sequence()).isEqualTo(4));
+  }
 
-    @Test
-    @DisplayName("vendor 응답이 null이면 예외가 발생한다")
-    void getRoute_vendorNull_throwsException() {
-        // given
-        UUID sourceHubId = UUID.randomUUID();
-        UUID vendorId = UUID.randomUUID();
+  @Test
+  @DisplayName("vendor 응답이 null이면 예외가 발생한다")
+  void getRoute_vendorNull_throwsException() {
+    // given
+    UUID sourceHubId = UUID.randomUUID();
+    UUID vendorId = UUID.randomUUID();
 
-        when(vendorClient.getVendor(vendorId)).thenReturn(null);
+    when(vendorClient.getVendor(vendorId)).thenReturn(null);
 
-        // when // then
-        assertThatThrownBy(() -> hubRouteService.getRoute(sourceHubId, vendorId))
-                .isInstanceOf(VendorNotFoundException.class);
-    }
+    // when // then
+    assertThatThrownBy(() -> hubRouteService.getRoute(sourceHubId, vendorId))
+        .isInstanceOf(VendorNotFoundException.class);
+  }
 
-    @Test
-    @DisplayName("vendor 응답의 hubId가 null이면 예외가 발생한다")
-    void getRoute_vendorHubIdNull_throwsException() {
-        // given
-        UUID sourceHubId = UUID.randomUUID();
-        UUID vendorId = UUID.randomUUID();
+  @Test
+  @DisplayName("vendor 응답의 hubId가 null이면 예외가 발생한다")
+  void getRoute_vendorHubIdNull_throwsException() {
+    // given
+    UUID sourceHubId = UUID.randomUUID();
+    UUID vendorId = UUID.randomUUID();
 
-        VendorResponse vendorResponse = new VendorResponse(
-                vendorId,
-                "허브없는업체",
-                VendorType.BUYER,
-                "설명",
-                null,
-                "사장님",
-                "주소",
-                0.0,
-                0.0
-        );
+    VendorResponse vendorResponse =
+        new VendorResponse(vendorId, "허브없는업체", VendorType.BUYER, "설명", null, "사장님", "주소", 0.0, 0.0);
 
-        when(vendorClient.getVendor(vendorId)).thenReturn(vendorResponse);
+    when(vendorClient.getVendor(vendorId)).thenReturn(vendorResponse);
 
-        // when // then
-        assertThatThrownBy(() -> hubRouteService.getRoute(sourceHubId, vendorId))
-                .isInstanceOf(InvalidVendorResponseException.class);
-    }
+    // when // then
+    assertThatThrownBy(() -> hubRouteService.getRoute(sourceHubId, vendorId))
+        .isInstanceOf(InvalidVendorResponseException.class);
+  }
 }

--- a/src/test/java/followMe/hub_server/hub/application/service/HubServiceImplTest.java
+++ b/src/test/java/followMe/hub_server/hub/application/service/HubServiceImplTest.java
@@ -266,7 +266,8 @@ class HubServiceImplTest {
       UUID userId = UUID.randomUUID();
       UUID hubId = UUID.randomUUID();
 
-      UserContext userContext = new UserContext(userId, UserRole.DELIVERY_MANAGER, null, null, null);
+      UserContext userContext =
+          new UserContext(userId, UserRole.DELIVERY_MANAGER, null, null, null);
       UpdateHubCommand command =
           new UpdateHubCommand(
               hubId, "수정된 허브", "수정된 주소", new BigDecimal("35.1234"), new BigDecimal("128.1234"));
@@ -351,7 +352,8 @@ class HubServiceImplTest {
       UUID userId = UUID.randomUUID();
       UUID hubId = UUID.randomUUID();
 
-      UserContext userContext = new UserContext(userId, UserRole.DELIVERY_MANAGER, null, null, null);
+      UserContext userContext =
+          new UserContext(userId, UserRole.DELIVERY_MANAGER, null, null, null);
 
       // when & then
       assertThatThrownBy(() -> hubService.deleteHub(userContext, hubId))

--- a/src/test/java/followMe/hub_server/hub/application/service/HubServiceImplTest.java
+++ b/src/test/java/followMe/hub_server/hub/application/service/HubServiceImplTest.java
@@ -48,7 +48,7 @@ class HubServiceImplTest {
     void createHub_master_success() {
       // given
       UUID userId = UUID.randomUUID();
-      UserContext userContext = new UserContext(userId, UserRole.MASTER, null, null);
+      UserContext userContext = new UserContext(userId, UserRole.MASTER, null, null, null);
 
       CreateHubCommand command =
           new CreateHubCommand(
@@ -82,7 +82,7 @@ class HubServiceImplTest {
       // given
       UUID userId = UUID.randomUUID();
       UserContext userContext =
-          new UserContext(userId, UserRole.HUB_MANAGER, UUID.randomUUID(), null);
+          new UserContext(userId, UserRole.HUB_MANAGER, UUID.randomUUID(), null, null);
 
       CreateHubCommand command =
           new CreateHubCommand(
@@ -182,7 +182,7 @@ class HubServiceImplTest {
       UUID userId = UUID.randomUUID();
       UUID hubId = UUID.randomUUID();
 
-      UserContext userContext = new UserContext(userId, UserRole.MASTER, null, null);
+      UserContext userContext = new UserContext(userId, UserRole.MASTER, null, null, null);
       UpdateHubCommand command =
           new UpdateHubCommand(
               hubId, "수정된 허브", "수정된 주소", new BigDecimal("35.1234"), new BigDecimal("128.1234"));
@@ -212,7 +212,7 @@ class HubServiceImplTest {
       UUID userId = UUID.randomUUID();
       UUID hubId = UUID.randomUUID();
 
-      UserContext userContext = new UserContext(userId, UserRole.HUB_MANAGER, hubId, null);
+      UserContext userContext = new UserContext(userId, UserRole.HUB_MANAGER, hubId, null, null);
       UpdateHubCommand command =
           new UpdateHubCommand(
               hubId, "수정된 허브", "수정된 주소", new BigDecimal("35.1234"), new BigDecimal("128.1234"));
@@ -243,7 +243,7 @@ class HubServiceImplTest {
       UUID myHubId = UUID.randomUUID();
       UUID targetHubId = UUID.randomUUID();
 
-      UserContext userContext = new UserContext(userId, UserRole.HUB_MANAGER, myHubId, null);
+      UserContext userContext = new UserContext(userId, UserRole.HUB_MANAGER, myHubId, null, null);
       UpdateHubCommand command =
           new UpdateHubCommand(
               targetHubId,
@@ -266,7 +266,7 @@ class HubServiceImplTest {
       UUID userId = UUID.randomUUID();
       UUID hubId = UUID.randomUUID();
 
-      UserContext userContext = new UserContext(userId, UserRole.DELIVERY_MANAGER, null, null);
+      UserContext userContext = new UserContext(userId, UserRole.DELIVERY_MANAGER, null, null, null);
       UpdateHubCommand command =
           new UpdateHubCommand(
               hubId, "수정된 허브", "수정된 주소", new BigDecimal("35.1234"), new BigDecimal("128.1234"));
@@ -290,7 +290,7 @@ class HubServiceImplTest {
       UUID userId = UUID.randomUUID();
       UUID hubId = UUID.randomUUID();
 
-      UserContext userContext = new UserContext(userId, UserRole.MASTER, null, null);
+      UserContext userContext = new UserContext(userId, UserRole.MASTER, null, null, null);
       Hub hub = mock(Hub.class);
 
       when(hubRepository.findById(hubId)).thenReturn(Optional.of(hub));
@@ -312,7 +312,7 @@ class HubServiceImplTest {
       UUID userId = UUID.randomUUID();
       UUID hubId = UUID.randomUUID();
 
-      UserContext userContext = new UserContext(userId, UserRole.HUB_MANAGER, hubId, null);
+      UserContext userContext = new UserContext(userId, UserRole.HUB_MANAGER, hubId, null, null);
       Hub hub = mock(Hub.class);
 
       when(hubRepository.findById(hubId)).thenReturn(Optional.of(hub));
@@ -335,7 +335,7 @@ class HubServiceImplTest {
       UUID myHubId = UUID.randomUUID();
       UUID targetHubId = UUID.randomUUID();
 
-      UserContext userContext = new UserContext(userId, UserRole.HUB_MANAGER, myHubId, null);
+      UserContext userContext = new UserContext(userId, UserRole.HUB_MANAGER, myHubId, null, null);
 
       // when & then
       assertThatThrownBy(() -> hubService.deleteHub(userContext, targetHubId))
@@ -351,7 +351,7 @@ class HubServiceImplTest {
       UUID userId = UUID.randomUUID();
       UUID hubId = UUID.randomUUID();
 
-      UserContext userContext = new UserContext(userId, UserRole.DELIVERY_MANAGER, null, null);
+      UserContext userContext = new UserContext(userId, UserRole.DELIVERY_MANAGER, null, null, null);
 
       // when & then
       assertThatThrownBy(() -> hubService.deleteHub(userContext, hubId))

--- a/src/test/java/followMe/hub_server/hub/presentation/controller/HubRouteControllerTest.java
+++ b/src/test/java/followMe/hub_server/hub/presentation/controller/HubRouteControllerTest.java
@@ -1,0 +1,95 @@
+package followMe.hub_server.hub.presentation.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import followMe.hub_server.common.config.JpaAuditConfig;
+import followMe.hub_server.hub.application.dto.enums.NodeType;
+import followMe.hub_server.hub.application.dto.result.HubRouteResult;
+import followMe.hub_server.hub.application.dto.result.RouteNodeResult;
+import followMe.hub_server.hub.application.service.HubRouteService;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+        controllers = HubRouteController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(
+                        type = FilterType.ASSIGNABLE_TYPE,
+                        classes = JpaAuditConfig.class
+                )
+        }
+)
+@AutoConfigureMockMvc(addFilters = false)
+@TestPropertySource(
+        properties = {
+                "spring.cloud.config.enabled=false",
+                "eureka.client.enabled=false",
+                "spring.cloud.discovery.enabled=false",
+                "spring.config.import=",
+                "spring.autoconfigure.exclude="
+                        + "org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration,"
+                        + "org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration"
+        }
+)
+@DisplayName("HubRouteController 단위 테스트")
+class HubRouteControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private HubRouteService hubRouteService;
+
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMappingContext;
+
+    @Test
+    @DisplayName("경로 조회 요청 시 nodes를 반환한다")
+    void getRoute_success() throws Exception {
+        UUID sourceHubId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        UUID vendorId = UUID.fromString("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb");
+
+        HubRouteResult result = new HubRouteResult(List.of(
+                new RouteNodeResult(sourceHubId, NodeType.HUB, "서울특별시 센터", 1),
+                new RouteNodeResult(
+                        UUID.fromString("88888888-8888-8888-8888-888888888888"),
+                        NodeType.HUB,
+                        "대전광역시 센터",
+                        2
+                ),
+                new RouteNodeResult(
+                        UUID.fromString("55555555-5555-5555-5555-555555555555"),
+                        NodeType.HUB,
+                        "대구광역시 센터",
+                        3
+                ),
+                new RouteNodeResult(vendorId, NodeType.VENDOR, "대구업체", 4)
+        ));
+
+        when(hubRouteService.getRoute(sourceHubId, vendorId)).thenReturn(result);
+
+        mockMvc.perform(get("/api/hubs/route")
+                        .param("sourceHubId", sourceHubId.toString())
+                        .param("vendorId", vendorId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nodes[0].type").value("HUB"))
+                .andExpect(jsonPath("$.nodes[0].name").value("서울특별시 센터"))
+                .andExpect(jsonPath("$.nodes[3].type").value("VENDOR"))
+                .andExpect(jsonPath("$.nodes[3].name").value("대구업체"))
+                .andExpect(jsonPath("$.nodes[3].sequence").value(4));
+    }
+}

--- a/src/test/java/followMe/hub_server/hub/presentation/controller/HubRouteControllerTest.java
+++ b/src/test/java/followMe/hub_server/hub/presentation/controller/HubRouteControllerTest.java
@@ -25,71 +25,64 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(
-        controllers = HubRouteController.class,
-        excludeFilters = {
-                @ComponentScan.Filter(
-                        type = FilterType.ASSIGNABLE_TYPE,
-                        classes = JpaAuditConfig.class
-                )
-        }
-)
+    controllers = HubRouteController.class,
+    excludeFilters = {
+      @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JpaAuditConfig.class)
+    })
 @AutoConfigureMockMvc(addFilters = false)
 @TestPropertySource(
-        properties = {
-                "spring.cloud.config.enabled=false",
-                "eureka.client.enabled=false",
-                "spring.cloud.discovery.enabled=false",
-                "spring.config.import=",
-                "spring.autoconfigure.exclude="
-                        + "org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration,"
-                        + "org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration"
-        }
-)
+    properties = {
+      "spring.cloud.config.enabled=false",
+      "eureka.client.enabled=false",
+      "spring.cloud.discovery.enabled=false",
+      "spring.config.import=",
+      "spring.autoconfigure.exclude="
+          + "org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration,"
+          + "org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration"
+    })
 @DisplayName("HubRouteController 단위 테스트")
 class HubRouteControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+  @Autowired private MockMvc mockMvc;
 
-    @MockitoBean
-    private HubRouteService hubRouteService;
+  @MockitoBean private HubRouteService hubRouteService;
 
-    @MockitoBean
-    private JpaMetamodelMappingContext jpaMappingContext;
+  @MockitoBean private JpaMetamodelMappingContext jpaMappingContext;
 
-    @Test
-    @DisplayName("경로 조회 요청 시 nodes를 반환한다")
-    void getRoute_success() throws Exception {
-        UUID sourceHubId = UUID.fromString("11111111-1111-1111-1111-111111111111");
-        UUID vendorId = UUID.fromString("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb");
+  @Test
+  @DisplayName("경로 조회 요청 시 nodes를 반환한다")
+  void getRoute_success() throws Exception {
+    UUID sourceHubId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    UUID vendorId = UUID.fromString("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb");
 
-        HubRouteResult result = new HubRouteResult(List.of(
+    HubRouteResult result =
+        new HubRouteResult(
+            List.of(
                 new RouteNodeResult(sourceHubId, NodeType.HUB, "서울특별시 센터", 1),
                 new RouteNodeResult(
-                        UUID.fromString("88888888-8888-8888-8888-888888888888"),
-                        NodeType.HUB,
-                        "대전광역시 센터",
-                        2
-                ),
+                    UUID.fromString("88888888-8888-8888-8888-888888888888"),
+                    NodeType.HUB,
+                    "대전광역시 센터",
+                    2),
                 new RouteNodeResult(
-                        UUID.fromString("55555555-5555-5555-5555-555555555555"),
-                        NodeType.HUB,
-                        "대구광역시 센터",
-                        3
-                ),
-                new RouteNodeResult(vendorId, NodeType.VENDOR, "대구업체", 4)
-        ));
+                    UUID.fromString("55555555-5555-5555-5555-555555555555"),
+                    NodeType.HUB,
+                    "대구광역시 센터",
+                    3),
+                new RouteNodeResult(vendorId, NodeType.VENDOR, "대구업체", 4)));
 
-        when(hubRouteService.getRoute(sourceHubId, vendorId)).thenReturn(result);
+    when(hubRouteService.getRoute(sourceHubId, vendorId)).thenReturn(result);
 
-        mockMvc.perform(get("/api/hubs/route")
-                        .param("sourceHubId", sourceHubId.toString())
-                        .param("vendorId", vendorId.toString()))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.nodes[0].type").value("HUB"))
-                .andExpect(jsonPath("$.nodes[0].name").value("서울특별시 센터"))
-                .andExpect(jsonPath("$.nodes[3].type").value("VENDOR"))
-                .andExpect(jsonPath("$.nodes[3].name").value("대구업체"))
-                .andExpect(jsonPath("$.nodes[3].sequence").value(4));
-    }
+    mockMvc
+        .perform(
+            get("/api/hubs/route")
+                .param("sourceHubId", sourceHubId.toString())
+                .param("vendorId", vendorId.toString()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.nodes[0].type").value("HUB"))
+        .andExpect(jsonPath("$.nodes[0].name").value("서울특별시 센터"))
+        .andExpect(jsonPath("$.nodes[3].type").value("VENDOR"))
+        .andExpect(jsonPath("$.nodes[3].name").value("대구업체"))
+        .andExpect(jsonPath("$.nodes[3].sequence").value(4));
+  }
 }


### PR DESCRIPTION
### 📌 관련 이슈
- close #14

### 💡 작업 내용
- 허브 간 최적 경로 조회 API를 추가했습니다.
- 업체 정보 기반 출발지/도착지 허브를 조회하고, 허브 경로를 계산하도록 구현했습니다.
- Vendor 서버 연동을 위한 Feign Client 및 요청 헤더 설정을 추가했습니다.
- 허브 경로 조회 성능 개선을 위해 캐시 설정을 적용했습니다.
- 서비스, 컨트롤러, 통합 테스트 및 단위 테스트를 작성했습니다.

### 📝 리뷰 포인트 (선택)
- HubRoutePathQueryService의 경로 탐색 로직이 의도한 방향으로 구현되었는지 봐주시면 감사하겠습니다!

### 🧠 기타 참고 사항
- 캐시 적용을 위해 build.gradle, application.yaml, CacheConfig 관련 설정이 포함되어 있습니다.
- 테스트는 Controller, Service, Integration 테스트까지 포함했습니다.